### PR TITLE
Add NextIPPacket method for capture.Source interface

### DIFF
--- a/capture/afpacket/tpacket.go
+++ b/capture/afpacket/tpacket.go
@@ -177,6 +177,11 @@ func (t tPacketHeader) payloadCopyPut(data []byte) {
 	copy(data, t.data[t.ppos+mac:t.ppos+mac+t.snapLen()])
 }
 
+func (t tPacketHeader) payloadCopyPutAtOffset(data []byte, offset uint32) {
+	mac := uint32(*(*uint16)(unsafe.Pointer(&t.data[t.ppos+24])))
+	copy(data, t.data[t.ppos+mac+offset:t.ppos+mac+t.snapLen()])
+}
+
 func (t tPacketHeader) payloadCopy() []byte {
 	rawPayload := t.payloadNoCopy()
 	cpPayload := make([]byte, len(rawPayload))

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -101,13 +101,18 @@ type Source interface {
 
 	// NextPacket receives the next packet from the wire and returns it. The operation is blocking. In
 	// case a non-nil "buffer" Packet is provided it will be populated with the data (and returned). The
-	// buffer packet can be reused. Otherwise a new Packet of the Source-specific type is allocated.
+	// buffer packet can be reused. Otherwise a new Packet is allocated.
 	NextPacket(pBuf Packet) (Packet, error)
 
 	// NextIPPacketFn executes the provided function on the next packet received on the wire and only
 	// return the ring buffer block to the kernel upon completion of the function. If possible, the
 	// operation should provide a zero-copy way of interaction with the payload / metadata.
 	NextPacketFn(func(payload []byte, totalLen uint32, pktType PacketType, ipLayerOffset byte) error) error
+
+	// NextIPPacket receives the next packet's IP layer from the wire and returns it. The operation is blocking.
+	// In case a non-nil "buffer" IPLayer is provided it will be populated with the data (and returned). The
+	// buffer packet can be reused. Otherwise a new IPLayer is allocated.
+	NextIPPacket(pBuf IPLayer) (IPLayer, PacketType, uint32, error)
 
 	// Stats returns (and clears) the packet counters of the underlying socket
 	Stats() (Stats, error)


### PR DESCRIPTION
Provides fast-path access to the IP layer for situations where potentially existing ethernet (or similar) layer(s) are not relevant. Avoids encoding of packet type, IP layer offset and total packet length in a `capture.Packet` and consequently:

- avoids additional allocation overhead for these parameters
- avoids unnecessary encoding + decoding calls (the latter potentially even over an interface) in case only the IP layer is relevant (as it is the case e.g. for `goProbe`)

Closes #8 