### PR TITLE
4 implement unblock stop logic for non ring source

### DIFF
--- a/capture/afpacket/afpacket.go
+++ b/capture/afpacket/afpacket.go
@@ -97,7 +97,7 @@ func setupRingBuffer(sd event.FileDescriptor, tPacketReq tPacketRequest) ([]byte
 		return nil, -1, errors.New("invalid socket")
 	}
 
-	// Setup event file descriptor used for stopping the capture (we start with that to avoid
+	// Setup event file descriptor used for stopping / unblocking the capture (we start with that to avoid
 	// having to clean up the ring buffer in case the decriptor can't be created
 	eventFD, err := event.NewEvtFileDescriptor()
 	if err != nil {

--- a/examples/dump/main.go
+++ b/examples/dump/main.go
@@ -44,13 +44,6 @@ func main() {
 	}
 	logger.Infof("Listening on interface `%s`: %+v", listener.Link().Name, listener.Link().Interface)
 
-	go func() {
-		time.Sleep(time.Second)
-		if err := listener.Close(); err != nil {
-			logger.Fatalf("failed to close listener on `%s`: %s", devName, err)
-		}
-	}()
-
 	logger.Infof("Reading %d packets from wire (copy operation)...", maxPkts)
 	for i := 0; i < maxPkts; i++ {
 		p, err := listener.NextPacket(nil)


### PR DESCRIPTION
Turns out it's possible to use the `PPOLL` syscall without a ring buffer (i.e. without a mmap'ed memory area) as well by setting up the same event handling logic and executing the `unix.Recvfrom` only upon receiving the appropriate event on the socket. This is obviously not "optimal" (in the sense of performance) because `unix.Recvfrom` was already blocking / waiting for packets, but IMHO this is outweighed by the fact that the event file descriptor is the only way to reliably stop / unblock a blocked capture (needed for graceful stop and rotations in goProbe and maybe similar scenarios, and also to achieve feature parity with the ring buffer source).
Given that the "plain" source is probably not the go-to choice for high-throughput situations anyway I think it's a good bargain. Should also help setting up a shared mock socket in https://github.com/fako1024/slimcap/issues/7 (because both sources now use the same socket / event logic).

Closes #4 