### PR TITLE
Provide enum for packet type / direction and fix direction logic

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -32,7 +32,16 @@ type Stats struct {
 }
 
 // PacketType denotes the packet type (indicating traffic direction)
+// https://github.com/torvalds/linux/blob/master/include/uapi/linux/if_packet.h
 type PacketType = byte
+
+const (
+	PacketThisHost  PacketType = iota // PacketThisHost: To us (unicast)
+	PacketBroadcast                   // PacketBroadcast: To all
+	PacketMulticast                   // PacketMulticast: To group
+	PacketOtherHost                   // PacketOtherHost: To someone else
+	PacketOutgoing                    // PacketOutgoing: Outgoing of any type
+)
 
 // IPLayer denotes the subset of bytes representing an IP layer
 type IPLayer []byte
@@ -176,4 +185,9 @@ func (p *Packet) IPLayer() IPLayer {
 // Type denotes the packet type (i.e. the packet direction w.r.t. the interface)
 func (p *Packet) Type() PacketType {
 	return (*p)[0]
+}
+
+// IsInbound denotes if the packet is inbound w.r.t. the interface
+func (p *Packet) IsInbound() bool {
+	return (*p)[0] != PacketOutgoing
 }

--- a/examples/dump/main.go
+++ b/examples/dump/main.go
@@ -50,7 +50,7 @@ func main() {
 		if err != nil {
 			logger.Fatalf("error during capture (copy operation) on `%s`: %s", devName, err)
 		}
-		logger.Infof("Received packet with Payload on `%s` (total len %d): %v (inbound: %v)", devName, p.TotalLen(), p.Payload(), p.Type() == 0)
+		logger.Infof("Received packet with Payload on `%s` (total len %d): %v (inbound: %v)", devName, p.TotalLen(), p.Payload(), p.IsInbound())
 	}
 
 	logger.Infof("Reading %d packets from wire (read into existing buffer)...", maxPkts)
@@ -59,13 +59,13 @@ func main() {
 		if p, err = listener.NextPacket(p); err != nil {
 			logger.Fatalf("error during capture (read into existing buffer) on `%s`: %s", devName, err)
 		}
-		logger.Infof("Received packet with Payload on `%s` (total len %d): %v (inbound: %v)", devName, p.TotalLen(), p.Payload(), p.Type() == 0)
+		logger.Infof("Received packet with Payload on `%s` (total len %d): %v (inbound: %v)", devName, p.TotalLen(), p.Payload(), p.IsInbound())
 	}
 
 	logger.Infof("Reading %d packets from wire (zero-copy function call)...", maxPkts)
 	for i := 0; i < maxPkts; i++ {
 		if err := listener.NextPacketFn(func(payload []byte, totalLen uint32, pktType, ipLayerOffset byte) (err error) {
-			logger.Infof("Received packet with Payload on `%s` (total len %d): %v (inbound: %v)", devName, totalLen, payload, pktType == 0)
+			logger.Infof("Received packet with Payload on `%s` (total len %d): %v (inbound: %v)", devName, totalLen, payload, p.IsInbound())
 			return
 		}); err != nil {
 			logger.Fatalf("error during capture (zero-copy function call) on `%s`: %s", devName, err)


### PR DESCRIPTION
This actually fixes a regression I introduced when implementing `slimcap` (wrong logic for determining if a packet is outbound). In practice this would have little effect (because it would only hit on broadcast / multicast and similar rare packets), but still. Will raise a matching issue on `goProbe` to amend the logic there. 

Closes #12 