### PR TITLE
11 provide automatic snaplen values

### DIFF
--- a/capture/afpacket/afpacket/afpacket_test.go
+++ b/capture/afpacket/afpacket/afpacket_test.go
@@ -6,20 +6,30 @@ import (
 	"testing"
 
 	"github.com/fako1024/slimcap/capture"
+	"github.com/fako1024/slimcap/link"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOptions(t *testing.T) {
 
 	t.Run("CaptureLength", func(t *testing.T) {
-		for _, captureLen := range []int{
-			1, 10, 64, 128, DefaultSnapLen, 2 * DefaultSnapLen,
+		for _, captureLen := range []link.CaptureLengthStrategy{
+			link.CaptureLengthFixed(1),
+			link.CaptureLengthFixed(10),
+			link.CaptureLengthFixed(64),
+			link.CaptureLengthFixed(128),
+			link.CaptureLengthFixed(DefaultSnapLen),
+			link.CaptureLengthFixed(2 * DefaultSnapLen),
+			link.CaptureLengthMinimalIPv4Header,
+			link.CaptureLengthMinimalIPv4Transport,
+			link.CaptureLengthMinimalIPv6Header,
+			link.CaptureLengthMinimalIPv6Transport,
 		} {
 			mockSrc, err := NewMockSource("mock",
 				CaptureLength(captureLen),
 			)
 			require.Nil(t, err)
-			require.Equal(t, captureLen, mockSrc.snapLen)
+			require.Equal(t, captureLen(mockSrc.link), mockSrc.snapLen)
 		}
 	})
 
@@ -103,7 +113,7 @@ func TestPipe(t *testing.T) {
 
 	// Setup the original mock source
 	mockSrc, err := NewMockSource("mock",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 	)
 	require.Nil(t, err)
@@ -131,7 +141,7 @@ func TestPipe(t *testing.T) {
 
 	// Setup the mock source used to pipe the first one
 	mockSrc2, err := NewMockSource("mock2",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 	)
 	require.Nil(t, err)
@@ -171,7 +181,7 @@ func BenchmarkCaptureMethods(b *testing.B) {
 
 	// Setup a mock source
 	mockSrc, err := NewMockSource("mock",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 	)
 	require.Nil(b, err)
@@ -240,7 +250,7 @@ func testCaptureMethods(t *testing.T, fn func(t *testing.T, src *MockSource, i, 
 
 	// Setup a mock source
 	mockSrc, err := NewMockSource("mock",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 	)
 	require.Nil(t, err)

--- a/capture/afpacket/afpacket/options.go
+++ b/capture/afpacket/afpacket/options.go
@@ -3,13 +3,15 @@
 
 package afpacket
 
+import "github.com/fako1024/slimcap/link"
+
 // Option denotes a functional option for the Source
 type Option func(*Source)
 
 // CaptureLength sets a snapLen / capture length (max. number of bytes captured per packet)
-func CaptureLength(snapLen int) Option {
+func CaptureLength(strategy link.CaptureLengthStrategy) Option {
 	return func(s *Source) {
-		s.snapLen = snapLen
+		s.snapLen = strategy(s.link)
 	}
 }
 

--- a/capture/afpacket/afring/afring_test.go
+++ b/capture/afpacket/afring/afring_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/fako1024/slimcap/capture"
+	"github.com/fako1024/slimcap/link"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,16 +36,25 @@ func TestBlockSizeAlignment(t *testing.T) {
 func TestOptions(t *testing.T) {
 
 	t.Run("CaptureLength", func(t *testing.T) {
-		for _, captureLen := range []int{
-			1, 10, 64, 128, DefaultSnapLen, 2 * DefaultSnapLen,
+		for _, captureLen := range []link.CaptureLengthStrategy{
+			link.CaptureLengthFixed(1),
+			link.CaptureLengthFixed(10),
+			link.CaptureLengthFixed(64),
+			link.CaptureLengthFixed(128),
+			link.CaptureLengthFixed(DefaultSnapLen),
+			link.CaptureLengthFixed(2 * DefaultSnapLen),
+			link.CaptureLengthMinimalIPv4Header,
+			link.CaptureLengthMinimalIPv4Transport,
+			link.CaptureLengthMinimalIPv6Header,
+			link.CaptureLengthMinimalIPv6Transport,
 		} {
 			mockSrc, err := NewMockSource("mock",
 				CaptureLength(captureLen),
 			)
 			require.Nil(t, err)
-			require.Equal(t, captureLen, mockSrc.snapLen)
+			require.Equal(t, captureLen(mockSrc.link), mockSrc.snapLen)
 
-			frameSize, err := blockSizeTPacketAlign(tPacketHeaderLen+captureLen, tPacketDefaultBlockSize)
+			frameSize, err := blockSizeTPacketAlign(tPacketHeaderLen+captureLen(mockSrc.link), tPacketDefaultBlockSize)
 			require.Nil(t, err)
 
 			require.Equal(t, uint32(frameSize), mockSrc.tpReq.frameSize)
@@ -89,7 +99,7 @@ func TestFillRingBuffer(t *testing.T) {
 
 	// Setup the original mock source
 	mockSrc, err := NewMockSource("mock",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 		BufferSize(1024*1024, 5),
 	)
@@ -185,7 +195,7 @@ func TestPipe(t *testing.T) {
 
 	// Setup the original mock source
 	mockSrc, err := NewMockSource("mock",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 		BufferSize(1024*1024, 5),
 	)
@@ -215,7 +225,7 @@ func TestPipe(t *testing.T) {
 
 	// Setup the mock source used to pipe the first one
 	mockSrc2, err := NewMockSource("mock2",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 	)
 	require.Nil(t, err)
@@ -255,7 +265,7 @@ func BenchmarkCaptureMethods(b *testing.B) {
 
 	// Setup a mock source
 	mockSrc, err := NewMockSource("mock",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 	)
 	require.Nil(b, err)
@@ -323,7 +333,7 @@ func testCaptureMethods(t *testing.T, fn func(t *testing.T, src *MockSource, i, 
 
 	// Setup a mock source
 	mockSrc, err := NewMockSource("mock",
-		CaptureLength(64),
+		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		Promiscuous(false),
 		BufferSize(1024*1024, 5),
 	)

--- a/capture/afpacket/afring/options.go
+++ b/capture/afpacket/afring/options.go
@@ -3,13 +3,15 @@
 
 package afring
 
+import "github.com/fako1024/slimcap/link"
+
 // Option denotes a functional option for the Source
 type Option func(*Source)
 
 // CaptureLength sets a snapLen / capture length (max. number of bytes captured per packet)
-func CaptureLength(snapLen int) Option {
+func CaptureLength(strategy link.CaptureLengthStrategy) Option {
 	return func(s *Source) {
-		s.snapLen = snapLen
+		s.snapLen = strategy(s.link)
 	}
 }
 

--- a/capture/pcap/pcap_test.go
+++ b/capture/pcap/pcap_test.go
@@ -116,7 +116,7 @@ func TestMockPipe(t *testing.T) {
 
 		// Setup a mock source
 		mockSrc, err := afring.NewMockSource("mock",
-			afring.CaptureLength(64),
+			afring.CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		)
 		require.Nil(t, err)
 		errChan := mockSrc.Pipe(src)

--- a/examples/dump/main.go
+++ b/examples/dump/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/fako1024/slimcap/capture/afpacket/afring"
+	"github.com/fako1024/slimcap/link"
 	"go.uber.org/zap"
 )
 
@@ -35,7 +36,7 @@ func main() {
 	}
 
 	listener, err := afring.NewSource(devName,
-		afring.CaptureLength(64),
+		afring.CaptureLength(link.CaptureLengthFixed(64)),
 		afring.BufferSize((1<<20), 4),
 		afring.Promiscuous(false),
 	)

--- a/link/snaplen.go
+++ b/link/snaplen.go
@@ -1,0 +1,44 @@
+package link
+
+import (
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// CaptureLengthStrategy denotes a strategy to calculate an optimal snaplen
+// for a link (type) depending on the use case
+type CaptureLengthStrategy = func(l *Link) int
+
+var (
+
+	// CaptureLengthFixed denotes a simple fixed snaplen strategy
+	CaptureLengthFixed = func(snaplen int) CaptureLengthStrategy {
+		return func(l *Link) int {
+			return snaplen
+		}
+	}
+
+	// CaptureLengthMinimalIPv4 indicates that the minimal necessary length to
+	// facilitate IPv4 layer analysis should be chosen
+	CaptureLengthMinimalIPv4Header = func(l *Link) int {
+		return int(l.Type.IpHeaderOffset()) + ipv4.HeaderLen // include full IPv4 header
+	}
+
+	// CaptureLengthMinimalIPv6 indicates that the minimal necessary length to
+	// facilitate IPv6 layer analysis should be chosen
+	CaptureLengthMinimalIPv6Header = func(l *Link) int {
+		return int(l.Type.IpHeaderOffset()) + ipv6.HeaderLen // include full IPv6 header
+	}
+
+	// CaptureLengthMinimalIPv4Transport indicates that the minimal necessary length to
+	// facilitate IPv4 transport layer analysis should be chosen
+	CaptureLengthMinimalIPv4Transport = func(l *Link) int {
+		return int(l.Type.IpHeaderOffset()) + ipv4.HeaderLen + 14 // include IPv4 transport layer up to TCP flag position
+	}
+
+	// CaptureLengthMinimalIPv6Transport indicates that the minimal necessary length to
+	// facilitate IPv6 transport layer analysis should be chosen
+	CaptureLengthMinimalIPv6Transport = func(l *Link) int {
+		return int(l.Type.IpHeaderOffset()) + ipv6.HeaderLen + 14 // include IPv4 transport layer up to TCP flag position
+	}
+)


### PR DESCRIPTION
Filed against #17 because this branch is based off that (PR #17 pending). Basically replaces the simple fixed integer value for the capture length (a.k.a. snaplen) with a functional approach that is not limited to setting a fixed value but allows the respective source to automatically choose the optimal snaplen based on a strategy (taking into account the link type and e.g. what the user intents to do with the captured data).

Closes #11 