### PR TITLE
[feature] Unify capture.Source interface(s) and add zero copy mode for ring buffer source

### DIFF
--- a/capture/afpacket/afring/tpacket.go
+++ b/capture/afpacket/afring/tpacket.go
@@ -95,7 +95,7 @@ func (t tPacketRequest) blockSizeNr() int {
 type tPacketHeader struct {
 	data      []byte
 	ppos      uint32
-	nPktsUsed uint32
+	nPktsLeft uint32
 }
 
 // / -> Block Descriptor
@@ -179,14 +179,19 @@ func (t tPacketHeader) payloadNoCopy() []byte {
 	return t.data[t.ppos+mac : t.ppos+mac+t.snapLen()]
 }
 
+func (t tPacketHeader) payloadNoCopyAtOffset(offset, to uint32) []byte {
+	mac := uint32(*(*uint16)(unsafe.Pointer(&t.data[t.ppos+24])))
+	return t.data[t.ppos+mac+offset : t.ppos+mac+to]
+}
+
 func (t tPacketHeader) payloadCopyPut(data []byte) {
 	mac := uint32(*(*uint16)(unsafe.Pointer(&t.data[t.ppos+24])))
 	copy(data, t.data[t.ppos+mac:t.ppos+mac+t.snapLen()])
 }
 
-func (t tPacketHeader) payloadCopyPutAtOffset(data []byte, offset uint32) {
+func (t tPacketHeader) payloadCopyPutAtOffset(data []byte, offset, to uint32) {
 	mac := uint32(*(*uint16)(unsafe.Pointer(&t.data[t.ppos+24])))
-	copy(data, t.data[t.ppos+mac+offset:t.ppos+mac+t.snapLen()])
+	copy(data, t.data[t.ppos+mac+offset:t.ppos+mac+to])
 }
 
 func (t tPacketHeader) payloadCopy() []byte {

--- a/capture/pcap/header.go
+++ b/capture/pcap/header.go
@@ -5,11 +5,11 @@ import (
 )
 
 const (
-	HeaderSize       = 24 // HeaderSize: Overall in-memory size of the main pcap file header
-	PacketHeaderSize = 16 // PacketHeaderSize: I-memory size of the packet specific header
+	HeaderSize       = 24 // HeaderSize : Overall in-memory size of the main pcap file header
+	PacketHeaderSize = 16 // PacketHeaderSize : I-memory size of the packet specific header
 
-	MagicNativeEndianess  = uint32(0xa1b2c3d4)
-	MagicSwappedEndianess = uint32(0xd4c3b2a1)
+	MagicNativeEndianess  = uint32(0xa1b2c3d4) // MagicNativeEndianess : endianess of local system
+	MagicSwappedEndianess = uint32(0xd4c3b2a1) // MagicSwappedEndianess : endianess of non-local / swapped system
 )
 
 // Header denotes the main pcap file header:
@@ -24,6 +24,7 @@ type Header struct {
 	Network      uint32
 }
 
+// SwapEndianess switches / swaps the endianess of the header
 func (h Header) SwapEndianess() Header {
 	return Header{
 		MagicNumber:  bits.ReverseBytes32(h.MagicNumber),
@@ -45,6 +46,7 @@ type PacketHeader struct {
 	OriginalLen int32
 }
 
+// SwapEndianess switches / swaps the endianess of the packet specific header
 func (h PacketHeader) SwapEndianess() PacketHeader {
 	return PacketHeader{
 		TSSec:       int32(bits.ReverseBytes32(uint32(h.TSSec))),

--- a/capture/pcap/pcap.go
+++ b/capture/pcap/pcap.go
@@ -69,8 +69,9 @@ func NewSource(iface string, r io.Reader) (*Source, error) {
 	return &obj, nil
 }
 
+// NewSourceFromFile instantiates a new pcap file capture source based on a file name
 func NewSourceFromFile(path string) (*Source, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
@@ -78,14 +79,15 @@ func NewSourceFromFile(path string) (*Source, error) {
 	return NewSource(filepath.Base(path), f)
 }
 
-// NewPacket creates an empty "buffer" package to be used as destination for the NextPacketInto()
-// method. It ensures that a valid packet of appropriate structure / length is created
+// NewPacket creates an empty "buffer" packet to be used as destination for the NextPacket() / NextPayload() /
+// NextIPPacket() methods (the latter two by calling .Payload() / .IPLayer() on the created buffer). It ensures
+// that a valid packet of appropriate structure / length is created
 func (s *Source) NewPacket() capture.Packet {
 	p := make(capture.Packet, int(s.header.Snaplen)+capture.PacketHdrOffset)
 	return p
 }
 
-// NextPacket receives the next packet from the wire and returns it. The operation is blocking. In
+// NextPacket receives the next packet from the source and returns it. The operation is blocking. In
 // case a non-nil "buffer" Packet is provided it will be populated with the data (and returned). The
 // buffer packet can be reused. Otherwise a new Packet is allocated.
 func (s *Source) NextPacket(pBuf capture.Packet) (capture.Packet, error) {
@@ -98,22 +100,22 @@ func (s *Source) NextPacket(pBuf capture.Packet) (capture.Packet, error) {
 	return capture.NewIPPacket(pBuf, s.buf, capture.PacketUnknown, int(pktHeader.OriginalLen), s.ipLayerOffset), nil
 }
 
-// NextIPPacketFn executes the provided function on the next packet received on the wire and only
-// return the ring buffer block to the kernel upon completion of the function. If possible, the
-// operation should provide a zero-copy way of interaction with the payload / metadata.
-func (s *Source) NextPacketFn(fn func(payload []byte, totalLen uint32, pktType capture.PacketType, ipLayerOffset byte) error) error {
+// NextPayload receives the raw payload of the next packet from the source and returns it. The operation is blocking.
+// In case a non-nil "buffer" byte slice / payload is provided it will be populated with the data (and returned).
+// The buffer can be reused. Otherwise a new byte slice / payload is allocated.
+func (s *Source) NextPayload(pBuf []byte) ([]byte, capture.PacketType, uint32, error) {
 
 	pktHeader, err := s.nextPacket()
 	if err != nil {
-		return err
+		return nil, capture.PacketUnknown, 0, err
 	}
 
-	return fn(s.buf, uint32(pktHeader.OriginalLen), capture.PacketUnknown, s.ipLayerOffset)
+	return s.buf, capture.PacketUnknown, uint32(pktHeader.OriginalLen), nil
 }
 
-// NextIPPacket receives the next packet's IP layer from the wire and returns it. The operation is blocking.
-// In case a non-nil "buffer" IPLayer is provided it will be populated with the data (and returned). The
-// buffer packet can be reused. Otherwise a new IPLayer is allocated.
+// NextIPPacket receives the IP layer of the next packet from the source and returns it. The operation is blocking.
+// In case a non-nil "buffer" IPLayer is provided it will be populated with the data (and returned).
+// The buffer can be reused. Otherwise a new IPLayer is allocated.
 func (s *Source) NextIPPacket(pBuf capture.IPLayer) (capture.IPLayer, capture.PacketType, uint32, error) {
 
 	pktHeader, err := s.nextPacket()
@@ -124,7 +126,20 @@ func (s *Source) NextIPPacket(pBuf capture.IPLayer) (capture.IPLayer, capture.Pa
 	return s.buf[s.ipLayerOffset:], capture.PacketUnknown, uint32(pktHeader.OriginalLen), nil
 }
 
-// Stats returns (and clears) the packet counters of the underlying socket
+// NextPacketFn executes the provided function on the next packet received on the source. If possible, the
+// operation should provide a zero-copy way of interaction with the payload / metadata. All operations on the data
+// must be completed prior to any subsequent call to any Next*() method.
+func (s *Source) NextPacketFn(fn func(payload []byte, totalLen uint32, pktType capture.PacketType, ipLayerOffset byte) error) error {
+
+	pktHeader, err := s.nextPacket()
+	if err != nil {
+		return err
+	}
+
+	return fn(s.buf, uint32(pktHeader.OriginalLen), capture.PacketUnknown, s.ipLayerOffset)
+}
+
+// Stats returns (and clears) the packet counters of the underlying source
 func (s *Source) Stats() (capture.Stats, error) {
 	stats := capture.Stats{
 		PacketsReceived: s.nPackets,
@@ -138,7 +153,8 @@ func (s *Source) Link() *link.Link {
 	return s.link
 }
 
-// Unblock ensures that a potentially ongoing blocking PPOLL is released (returning an ErrCaptureUnblock)
+// Unblock ensures that a potentially ongoing blocking poll operation is released (returning an ErrCaptureUnblock from
+// any potentially ongoing call to Next*() that might currently be blocked)
 func (s *Source) Unblock() error {
 	return nil
 }

--- a/capture/pcap/pcap_test.go
+++ b/capture/pcap/pcap_test.go
@@ -161,6 +161,34 @@ func TestCaptureMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("NextPayload", func(t *testing.T) {
+		testCaptureMethods(t, func(t *testing.T, src *Source) {
+			p, pktType, totalLen, err := src.NextPayload(nil)
+			require.Nil(t, err)
+			require.NotNil(t, p)
+			require.Equal(t, capture.PacketUnknown, pktType)
+			require.NotZero(t, totalLen)
+		})
+	})
+
+	t.Run("NextPayloadInPlace", func(t *testing.T) {
+		var p capture.IPLayer
+		testCaptureMethods(t, func(t *testing.T, src *Source) {
+
+			// Use NewPacket() method of source to instantiate a new reusable packet buffer
+			if cap(p) == 0 {
+				pkt := src.NewPacket()
+				p = pkt.Payload()
+			}
+
+			_, pktType, totalLen, err := src.NextPayload(p)
+			require.Nil(t, err)
+			require.NotNil(t, p)
+			require.Equal(t, capture.PacketUnknown, pktType)
+			require.NotZero(t, totalLen)
+		})
+	})
+
 	t.Run("NextIPPacket", func(t *testing.T) {
 		testCaptureMethods(t, func(t *testing.T, src *Source) {
 			p, pktType, totalLen, err := src.NextIPPacket(nil)

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -1,0 +1,350 @@
+package link
+
+import (
+	"io/fs"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/bpf"
+)
+
+func TestIsUp(t *testing.T) {
+	link, _ := New("lo")
+
+	want := true
+	got := link.IsUp()
+
+	if got != want {
+		t.Errorf("IsUp() returned wrong value: got %v, want %v", got, want)
+	}
+}
+
+func TestFindAllLinks(t *testing.T) {
+	links, err := FindAllLinks()
+
+	if err != nil {
+		t.Errorf("FindAllLinks() returned error: %v", err)
+	}
+
+	for _, link := range links {
+		if link == nil {
+			t.Errorf("FindAllLinks() returned nil link")
+		}
+	}
+}
+
+func TestGetLinkType(t *testing.T) {
+	want := TypeLoopback
+	got, err := getLinkType("lo")
+
+	if err != nil {
+		t.Errorf("getLinkType() returned error: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("getLinkType() returned wrong value: got %v, want %v", got, want)
+	}
+}
+
+func TestIpHeaderOffset(t *testing.T) {
+	tests := []struct {
+		name     string
+		linkType Type
+		want     byte
+	}{
+		{"TypeEthernet", TypeEthernet, IPLayerOffsetEthernet},
+		{"TypeLoopback", TypeLoopback, IPLayerOffsetEthernet},
+		{"TypePPP", TypePPP, 0},
+		{"TypeGRE", TypeGRE, 0},
+		{"TypeNone", TypeNone, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.linkType.IpHeaderOffset(); got != tt.want {
+				t.Errorf("IpHeaderOffset() = %v, want %v for link type %v", got, tt.want, tt.linkType)
+			}
+		})
+	}
+}
+
+func TestBPFFilter(t *testing.T) {
+	snaplen := 4096
+	tests := []struct {
+		name     string
+		linkType Type
+	}{
+		{"TypeEthernet", TypeEthernet},
+		{"TypeLoopback", TypeLoopback},
+		{"TypePPP", TypePPP},
+		{"TypeGRE", TypeGRE},
+		{"TypeNone", TypeNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := tt.linkType.BPFFilter()(snaplen)
+			if filter == nil {
+				t.Errorf("BPFFilter() returned nil filter")
+			}
+		})
+	}
+}
+
+func TestLink_IpHeaderOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		l    Type
+		want byte
+	}{
+		{
+			name: "Test Ethernet link IP Header Offset",
+			l:    TypeEthernet,
+			want: IPLayerOffsetEthernet,
+		},
+		{
+			name: "Test Loopback link IP Header Offset",
+			l:    TypeLoopback,
+			want: IPLayerOffsetEthernet,
+		},
+		{
+			name: "Test PPP link IP Header Offset",
+			l:    TypePPP,
+			want: 0,
+		},
+		{
+			name: "Test GRE link IP Header Offset",
+			l:    TypeGRE,
+			want: 0,
+		},
+		{
+			name: "Test None link IP Header Offset",
+			l:    TypeNone,
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.l.IpHeaderOffset(); got != tt.want {
+				t.Errorf("Link.IpHeaderOffset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLink_BPFFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		l        Type
+		wantFunc func(snapLen int) []bpf.RawInstruction
+	}{
+		{
+			name: "Test Ethernet link BPF Filter Function",
+			l:    TypeEthernet,
+			wantFunc: func(snapLen int) []bpf.RawInstruction {
+				return bpfInstructionsLinkTypeEther(snapLen)
+			},
+		},
+		{
+			name: "Test Loopback link BPF Filter Function",
+			l:    TypeLoopback,
+			wantFunc: func(snapLen int) []bpf.RawInstruction {
+				return bpfInstructionsLinkTypeEther(snapLen)
+			},
+		},
+		{
+			name: "Test PPP link BPF Filter Function",
+			l:    TypePPP,
+			wantFunc: func(snapLen int) []bpf.RawInstruction {
+				return bpfInstructionsLinkTypeRaw(snapLen)
+			},
+		},
+		{
+			name: "Test GRE link BPF Filter Function",
+			l:    TypeGRE,
+			wantFunc: func(snapLen int) []bpf.RawInstruction {
+				return bpfInstructionsLinkTypeRaw(snapLen)
+			},
+		},
+		{
+			name: "Test None link BPF Filter Function",
+			l:    TypeNone,
+			wantFunc: func(snapLen int) []bpf.RawInstruction {
+				return bpfInstructionsLinkTypeRaw(snapLen)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotFunc := tt.l.BPFFilter(); !assert.ObjectsAreEqual(gotFunc(65536), tt.wantFunc(65536)) {
+				t.Errorf("Link.BPFFilter() = %v, want %v", gotFunc(65536), tt.wantFunc(65536))
+			}
+		})
+	}
+}
+
+func TestLink_FindAllLinks(t *testing.T) {
+	tests := []struct {
+		name    string
+		mockFn  func() ([]net.Interface, error)
+		wantErr error
+	}{
+		{
+			name: "Test Find All Links Success",
+			mockFn: func() ([]net.Interface, error) {
+				return []net.Interface{
+					{Name: "eth0", Flags: syscall.IFF_UP},
+					{Name: "eth1", Flags: syscall.IFF_UP},
+					{Name: "lo", Flags: syscall.IFF_UP},
+				}, nil
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Test Find All Links Error",
+			mockFn: func() ([]net.Interface, error) {
+				return nil, fs.ErrNotExist
+			},
+			wantErr: &fs.PathError{
+				Op:   "open",
+				Path: "/sys/class/net/",
+				Err:  fs.ErrNotExist,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			netInterfaces = &mockInterfaces{mockFn: tt.mockFn}
+			got, err := FindAllLinks()
+			if err != nil {
+				if !assert.EqualError(t, err, tt.wantErr.Error()) {
+					t.Errorf("Link_FindAllLinks() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			require.True(t, len(got) > 0)
+			for _, l := range got {
+				assert.NotNil(t, l)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	type args struct {
+		ifName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		mockFn  func(ifName string) (Type, error)
+		want    *Link
+		wantErr bool
+	}{
+		{
+			name: "Test New Fail Interface not found",
+			args: args{ifName: "eth2"},
+			mockFn: func(ifName string) (Type, error) {
+				return -1, fs.ErrNotExist
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Test New Fail Interface not up",
+			args: args{ifName: "eth1"},
+			mockFn: func(ifName string) (Type, error) {
+				return TypeEthernet, nil
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Test New Fail Invalid Link Type",
+			args: args{ifName: "eth0"},
+			mockFn: func(ifName string) (Type, error) {
+				return TypeInvalid, nil
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getLinkTypeF = tt.mockFn
+			got, err := New(tt.args.ifName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Link.New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !assert.ObjectsAreEqual(got, tt.want) {
+				t.Errorf("Link.New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLink_IsUp(t *testing.T) {
+	type fields struct {
+		Type Type
+		net.Interface
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "Test Up Interface",
+			fields: fields{
+				Type: TypeEthernet,
+				Interface: net.Interface{
+					Name:  "eth0",
+					Flags: syscall.IFF_UP,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Test Down Interface",
+			fields: fields{
+				Type: TypeEthernet,
+				Interface: net.Interface{
+					Name:  "eth0",
+					Flags: 0,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Link{
+				Type:      tt.fields.Type,
+				Interface: &tt.fields.Interface,
+			}
+			if got := l.IsUp(); got != tt.want {
+				t.Errorf("Link.IsUp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type mockInterfaces struct {
+	mockFn func() ([]net.Interface, error)
+}
+
+var netInterfaces = &mockInterfaces{
+	mockFn: func() ([]net.Interface, error) {
+		return nil, nil
+	},
+}
+
+func (m *mockInterfaces) Interfaces() ([]net.Interface, error) {
+	return m.mockFn()
+}
+
+var getLinkTypeF = func(ifName string) (Type, error) { return 1, nil }

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -246,7 +246,7 @@ func TestNew(t *testing.T) {
 	}{
 		{
 			name: "Test New Fail Interface not found",
-			args: args{ifName: "eth2"},
+			args: args{ifName: "ethDoesNotReallyExist"},
 			mockFn: func(ifName string) (Type, error) {
 				return -1, fs.ErrNotExist
 			},
@@ -255,7 +255,7 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name: "Test New Fail Interface not up",
-			args: args{ifName: "eth1"},
+			args: args{ifName: "ethDoesNotReallyExist"},
 			mockFn: func(ifName string) (Type, error) {
 				return TypeEthernet, nil
 			},
@@ -264,7 +264,7 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name: "Test New Fail Invalid Link Type",
-			args: args{ifName: "eth0"},
+			args: args{ifName: "ethDoesNotReallyExist"},
 			mockFn: func(ifName string) (Type, error) {
 				return TypeInvalid, nil
 			},


### PR DESCRIPTION
Unifies the `capture.Source` interface (and adds a new `capture.SourceZeroCopy` one to indicate zero-copy capabilities), cleans up some code and improves capture performance (for all methods, but of course most prominently when using the zero-copy methods of the ring buffer source). Also fixes some minor Linter warnings and cleans up code structure & comments.

Closes #18 