### PR TITLE
[bugfix] Add missing interface wrap for SourceZeroCopy

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -153,7 +153,7 @@ type SourceZeroCopy interface {
 
 	// NextPayloadZeroCopy receives the raw payload of the next packet from the source and returns it. The operation is blocking.
 	// The returned payload provides direct zero-copy access to the underlying data source (e.g. a ring buffer).
-	NextPayloadZeroCopy() ([]byte, error)
+	NextPayloadZeroCopy() ([]byte, PacketType, uint32, error)
 
 	// NextIPPacketZeroCopy receives the IP layer of the next packet from the source and returns it. The operation is blocking.
 	// The returned IPLayer provides direct zero-copy access to the underlying data source (e.g. a ring buffer).

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -158,6 +158,9 @@ type SourceZeroCopy interface {
 	// NextIPPacketZeroCopy receives the IP layer of the next packet from the source and returns it. The operation is blocking.
 	// The returned IPLayer provides direct zero-copy access to the underlying data source (e.g. a ring buffer).
 	NextIPPacketZeroCopy() (IPLayer, PacketType, uint32, error)
+	
+	// Wrap generic Source
+	Source
 }
 
 // Packet denotes a packet retrieved via the AF_PACKET ring buffer,


### PR DESCRIPTION
Quick fix for an obvious lapse on my part: I forgot to wrap the generic / common `Source` in the new `SourceZeroCopy` interface, making it quite hard to use the latter as a Source across the codebase :stuck_out_tongue: 

@els0r I'd greatly appreciate an "AFK"-style approval :wink: 