### PR TITLE
[bugfix] Fix incorrect handling of mock ring buffer wrap around

### DIFF
--- a/capture/afpacket/afring/afring.go
+++ b/capture/afpacket/afring/afring.go
@@ -366,12 +366,12 @@ fetch:
 			}
 
 			// Handle rare cases of runaway packets
-			if s.curTPacketHeader.getStatus()&tPacketStatusCopy != 0 {
+			if s.curTPacketHeader.getStatus()&unix.TP_STATUS_COPY != 0 {
 				if s.curTPacketHeader.nPktsLeft != 0 {
 					fmt.Println(s.link.Name, "WUT (after runaway packet)?", s.curTPacketHeader.nPktsLeft)
 				}
-				s.curTPacketHeader.setStatus(tPacketStatusKernel)
-				s.offset = (s.offset + 1) % int(s.tpReq.frameNr)
+				s.curTPacketHeader.setStatus(unix.TP_STATUS_KERNEL)
+				s.offset = (s.offset + 1) % int(s.tpReq.blockNr)
 				s.curTPacketHeader = s.nextTPacketHeader()
 
 				continue
@@ -390,7 +390,7 @@ fetch:
 			if nextPos != 0 {
 				fmt.Println(s.link.Name, "WUT (after resetting)?", s.curTPacketHeader.nPktsLeft, nextPos)
 			}
-			s.curTPacketHeader.setStatus(tPacketStatusKernel)
+			s.curTPacketHeader.setStatus(unix.TP_STATUS_KERNEL)
 			s.offset = (s.offset + 1) % int(s.tpReq.blockNr)
 			s.curTPacketHeader = nil
 			goto fetch

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -15,7 +15,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const mac = 82
+const (
+	mac                     = 82
+	blockStatusPollInterval = 10 * time.Millisecond
+)
 
 // MockSource denotes a fully mocked ring buffer source, behaving just like one
 // Since it wraps a regular Source, it can be used as a stand-in replacement without any further
@@ -112,7 +115,7 @@ func (m *MockSource) addPacket(payload []byte, totalLen uint32, pktType, ipLayer
 		// Ensure that the packet has already been consumed to avoid race conditions (since there is no
 		// feedback from the receiver we can only poll until the packet status is not TP_STATUS_KERNEL)
 		for m.getBlockStatus(thisBlock) != unix.TP_STATUS_KERNEL {
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(blockStatusPollInterval)
 		}
 
 		m.markBlock(thisBlock, unix.TP_STATUS_CSUMNOTREADY)

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -49,7 +49,7 @@ func NewMockSource(iface string, options ...Option) (*MockSource, error) {
 		blockSize: tPacketDefaultBlockSize,
 		nBlocks:   tPacketDefaultBlockNr,
 
-		ipLayerOffset: link.Type(link.TypeEthernet).IpHeaderOffset(),
+		ipLayerOffset: link.TypeEthernet.IpHeaderOffset(),
 		link: &link.Link{
 			Type: link.TypeEthernet,
 			Interface: &net.Interface{
@@ -86,8 +86,8 @@ func NewMockSource(iface string, options ...Option) (*MockSource, error) {
 // This can happen prior to calling run or continuously while consuming data, mimicking the
 // function of an actual ring buffer. Consequently, if the ring buffer is full and elements not
 // yet consumed this function may block
-func (m *MockSource) AddPacket(pkt capture.Packet) {
-	m.addPacket(pkt.Payload(), pkt.TotalLen(), pkt.Type(), 0)
+func (m *MockSource) AddPacket(pkt capture.Packet) error {
+	return m.addPacket(pkt.Payload(), pkt.TotalLen(), pkt.Type(), 0)
 }
 
 // AddPacketFromSource consumes a single packet from the provided source and adds it to the source
@@ -107,12 +107,19 @@ func (m *MockSource) addPacket(payload []byte, totalLen uint32, pktType, ipLayer
 		if m.curBlockPos > 0 {
 			m.FinalizeBlock(false)
 		}
-		m.curBlockPos = tPacketHeaderLen
 		thisBlock = m.mockBlockCount % m.nBlocks
 
-		*(*uint32)(unsafe.Pointer(&m.ringBuffer.ring[thisBlock*m.blockSize])) = 3                       // version
-		*(*uint32)(unsafe.Pointer(&m.ringBuffer.ring[thisBlock*m.blockSize+8])) = unix.TP_STATUS_KERNEL // status
-		*(*uint32)(unsafe.Pointer(&m.ringBuffer.ring[thisBlock*m.blockSize+16])) = tPacketHeaderLen     // offsetToFirstPkt
+		// Ensure that the packet has already been consumed to avoid race conditions (since there is no
+		// feedback from the receiver we can only poll until the packet status is not TP_STATUS_KERNEL)
+		for m.getBlockStatus(thisBlock) != unix.TP_STATUS_KERNEL {
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		m.markBlock(thisBlock, unix.TP_STATUS_CSUMNOTREADY)
+		m.curBlockPos = tPacketHeaderLen
+		*(*uint32)(unsafe.Pointer(&m.ringBuffer.ring[thisBlock*m.blockSize])) = 3                   // version
+		*(*uint32)(unsafe.Pointer(&m.ringBuffer.ring[thisBlock*m.blockSize+12])) = 0                // nPkts
+		*(*uint32)(unsafe.Pointer(&m.ringBuffer.ring[thisBlock*m.blockSize+16])) = tPacketHeaderLen // offsetToFirstPkt
 	}
 
 	block := m.ringBuffer.ring[thisBlock*m.blockSize : thisBlock*m.blockSize+m.blockSize]
@@ -127,7 +134,7 @@ func (m *MockSource) addPacket(payload []byte, totalLen uint32, pktType, ipLayer
 	if m.curBlockPos > tPacketHeaderLen {
 		*(*uint32)(unsafe.Pointer(&block[m.curBlockPos-mac-m.snapLen])) = uint32(mac + m.snapLen) // nextOffset
 	}
-	*(*uint32)(unsafe.Pointer(&block[12])) = *(*uint32)(unsafe.Pointer(&block[12])) + 1 // nPkts                                            // TPacket data
+	*(*uint32)(unsafe.Pointer(&block[12])) = *(*uint32)(unsafe.Pointer(&block[12])) + 1 // nPkts
 	m.curBlockPos += mac + m.snapLen
 
 	// Similar to the actual kernel ring buffer, we count packets as "seen" when they enter
@@ -262,17 +269,8 @@ func (m *MockSource) run(errChan chan error) {
 			break
 		}
 
-		thisBlock := block % m.nBlocks
-
-		// Ensure that the packet has already been consumed to avoid race conditions (since there is no
-		// feedback from the receiver we can only poll until the packet status is not TP_STATUS_USER)
-		for m.getBlockStatus(thisBlock) == unix.TP_STATUS_USER {
-			time.Sleep(100 * time.Millisecond)
-		}
-
-		// Store the next block in the ring buffer and mark it to be available to the reader
-		// copy(m.ringBuffer.ring[thisBlock*m.blockSize:thisBlock*m.blockSize+m.blockSize], block)
-		m.markBlock(thisBlock, unix.TP_STATUS_USER)
+		// Mark the next block in the ring buffer, making it available to the reader / userspace
+		m.markBlock(block%m.nBlocks, unix.TP_STATUS_USER)
 
 		// Queue / trigger an event equivalent to receiving a new block via the PPOLL syscall
 		if err := event.ToMockHandler(m.eventHandler).SignalAvailableData(); err != nil {
@@ -292,11 +290,13 @@ func (m *MockSource) markBlock(n int, status uint32) {
 	*(*uint32)(unsafe.Pointer(&m.ringBuffer.ring[n*m.blockSize+8])) = status
 }
 
+// Close stops / closes the capture source
 func (m *MockSource) Close() error {
 	m.isClosed = true
 	return m.Source.Close()
 }
 
+// Free releases any pending resources from the capture source (must be called after Close())
 func (m *MockSource) Free() error {
 	m.ringBuffer.ring = nil
 	return nil

--- a/capture/afpacket/afring/tpacket.go
+++ b/capture/afpacket/afring/tpacket.go
@@ -17,10 +17,6 @@ const (
 )
 
 const (
-	tPacketStatusKernel = 0
-	tPacketStatusUser   = (1 << 0)
-	tPacketStatusCopy   = (1 << 1)
-
 	tPacketDefaultBlockNr   = 4         // sizeof(tpacket3_hdr)
 	tPacketDefaultBlockSize = (1 << 20) // 1 MiB
 	tPacketDefaultBlockTOV  = 100       // ms


### PR DESCRIPTION
@els0r FYI, this should fix the issues mentioned [here](https://github.com/els0r/goProbe/issues/88#issuecomment-1518602902). Luckily it turned out _not_ to be a fundamental race condition, just incorrect handling (and missing tests) for the mock ring buffer wrap-around. The memory barrier in place via the `TPacket` status field seems to mimic the "real" kernel buffer sufficiently without additional synchronization.

Closes #24 