### PR TITLE
[bugfix] Fix warning about false remaining packets in ring buffer when piping mock sources

### DIFF
--- a/capture/afpacket/afring/afring_test.go
+++ b/capture/afpacket/afring/afring_test.go
@@ -235,7 +235,7 @@ func TestPipe(t *testing.T) {
 
 	// Setup the original mock source
 	mockSrc, err := NewMockSource("mock",
-		CaptureLength(link.CaptureLengthMinimalIPv4Transport),
+		CaptureLength(link.CaptureLengthMinimalIPv6Transport),
 		Promiscuous(false),
 		BufferSize(1024*16, 8),
 	)
@@ -259,6 +259,7 @@ func TestPipe(t *testing.T) {
 				require.Nil(t, mockSrc.AddPacket(p))
 			}
 		}
+
 		mockSrc.FinalizeBlock(false)
 		mockSrc.Done()
 	}()


### PR DESCRIPTION
Closes #28 