### PR TITLE
[bugfix] Ring buffer block not automatically released without call to nextPacket()

### DIFF
--- a/capture/afpacket/afpacket/afpacket.go
+++ b/capture/afpacket/afpacket/afpacket.go
@@ -187,7 +187,7 @@ func (s *Source) NextIPPacket(pBuf capture.IPLayer) (capture.IPLayer, capture.Pa
 // must be completed prior to any subsequent call to any Next*() method.
 func (s *Source) NextPacketFn(fn func(payload []byte, totalLen uint32, pktType capture.PacketType, ipLayerOffset byte) error) error {
 
-	if s.eventHandler.Fd == 0 {
+	if !s.eventHandler.Fd.IsOpen() {
 		return errors.New("cannot NextPacketFn() on closed capture source")
 	}
 
@@ -268,8 +268,6 @@ func (s *Source) Close() error {
 		return err
 	}
 
-	s.eventHandler.Fd = -1
-
 	return nil
 }
 
@@ -278,7 +276,7 @@ func (s *Source) Free() error {
 	if s == nil {
 		return errors.New("cannot call Free() on nil capture source")
 	}
-	if s.eventHandler.Fd >= 0 {
+	if !s.eventHandler.Fd.IsOpen() {
 		return errors.New("cannot call Free() on open capture source, call Close() first")
 	}
 
@@ -289,7 +287,7 @@ func (s *Source) Free() error {
 
 func (s *Source) nextPacketInto(data capture.Packet) (int, error) {
 
-	if s.eventHandler.Fd == 0 {
+	if !s.eventHandler.Fd.IsOpen() {
 		return -1, errors.New("cannot nextPacketInto() on closed capture source")
 	}
 
@@ -332,7 +330,7 @@ retry:
 
 func (s *Source) nextPayloadInto(data capture.IPLayer) (int, capture.PacketType, uint32, error) {
 
-	if s.eventHandler.Fd == 0 {
+	if !s.eventHandler.Fd.IsOpen() {
 		return -1, capture.PacketUnknown, 0, errors.New("cannot nextPacketInto() on closed capture source")
 	}
 

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -327,7 +327,5 @@ func (m *MockSource) Close() error {
 // Free releases any pending resources from the capture source (must be called after Close())
 func (m *MockSource) Free() error {
 	m.ringBuffer.ring = nil
-
-	// panic("stack")
 	return nil
 }

--- a/capture/afpacket/afring/tpacket.go
+++ b/capture/afpacket/afring/tpacket.go
@@ -6,6 +6,7 @@ package afring
 import (
 	"fmt"
 	"math"
+	"sync/atomic"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -105,11 +106,11 @@ func (t tPacketHeader) privOffset() uint32 {
 
 // / -> Block Header
 func (t tPacketHeader) getStatus() uint32 {
-	return *(*uint32)(unsafe.Pointer(&t.data[8]))
+	return atomic.LoadUint32((*uint32)(unsafe.Pointer(&t.data[8])))
 }
 
 func (t tPacketHeader) setStatus(status uint32) {
-	*(*uint32)(unsafe.Pointer(&t.data[8])) = status
+	atomic.StoreUint32((*uint32)(unsafe.Pointer(&t.data[8])), status)
 }
 
 func (t tPacketHeader) nPkts() uint32 {

--- a/capture/afpacket/socket/socket.go
+++ b/capture/afpacket/socket/socket.go
@@ -115,6 +115,12 @@ func (sd FileDescriptor) Close() error {
 	return unix.Close(int(sd))
 }
 
+// IsOpen determines if the file descriptor is open / valid
+func (sd FileDescriptor) IsOpen() bool {
+	_, err := unix.FcntlInt(uintptr(sd), unix.F_GETFD, 0)
+	return err == nil
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
 
 func getsockopt(fd FileDescriptor, level, name int, val unsafe.Pointer, vallen uintptr) error {

--- a/capture/pcap/pcap_test.go
+++ b/capture/pcap/pcap_test.go
@@ -140,6 +140,7 @@ func TestMockPipe(t *testing.T) {
 			require.Equal(t, capture.PacketUnknown, p.Type())
 			require.NotZero(t, p.TotalLen())
 		}
+		mockSrc.ForceBlockRelease()
 
 		// Block and check for any errors that may have happened while piping
 		require.Nil(t, <-errChan)


### PR DESCRIPTION
Provides several small fixes and some improvements for testing via mock source(s). See inline comments for some pointers.

Closes #33 