### PR TITLE
[bugfix] Make mock socket packet counter interaction atomic

### DIFF
--- a/capture/afpacket/socket/socket_test.go
+++ b/capture/afpacket/socket/socket_test.go
@@ -1,0 +1,64 @@
+package socket
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const nPolls = 1000000
+
+func TestBasicInteraction(t *testing.T) {
+
+	sock, err := NewMock()
+	require.Nil(t, err)
+	require.True(t, sock.IsOpen())
+
+	sock.IncrementPacketCount(1)
+
+	stats, err := sock.GetSocketStats()
+	require.Nil(t, err)
+	require.EqualValues(t, TPacketStats{Packets: 1}, stats)
+
+	require.Nil(t, sock.Close())
+	require.False(t, sock.IsOpen())
+
+	stats, err = sock.GetSocketStats()
+	require.EqualError(t, err, "invalid socket")
+	require.EqualValues(t, TPacketStats{}, stats)
+}
+
+func TestPacketCounter(t *testing.T) {
+
+	sock, err := NewMock()
+	require.Nil(t, err)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		for i := 0; i < nPolls; i++ {
+			sock.IncrementPacketCount(1)
+		}
+		wg.Done()
+	}()
+
+	go func(t *testing.T) {
+		var nPacketsSeen uint32
+		for {
+			stats, err := sock.GetSocketStats()
+			require.Nil(t, err)
+
+			nPacketsSeen += stats.Packets
+			if nPacketsSeen == nPolls {
+				wg.Done()
+				return
+			}
+		}
+	}(t)
+
+	wg.Wait()
+
+	require.Nil(t, sock.Close())
+}


### PR DESCRIPTION
@els0r Addresses one of the data races discovered in https://github.com/els0r/goProbe/issues/117 - Since it's basically trivial and I need the changes for https://github.com/els0r/goProbe/issues/88 I hope you're fine with me forcing the merge without previous approval. Feel free to re-open the issue or comment in case you find something that should be addressed. 

Closes #35 