### PR TITLE
[feature] Support notification after data consumption during Pipe()

### DIFF
--- a/capture/afpacket/afpacket/afpacket.go
+++ b/capture/afpacket/afpacket/afpacket.go
@@ -188,7 +188,7 @@ func (s *Source) NextIPPacket(pBuf capture.IPLayer) (capture.IPLayer, capture.Pa
 func (s *Source) NextPacketFn(fn func(payload []byte, totalLen uint32, pktType capture.PacketType, ipLayerOffset byte) error) error {
 
 	if !s.eventHandler.Fd.IsOpen() {
-		return errors.New("cannot NextPacketFn() on closed capture source")
+		return capture.ErrCaptureStopped
 	}
 
 retry:
@@ -288,7 +288,7 @@ func (s *Source) Free() error {
 func (s *Source) nextPacketInto(data capture.Packet) (int, error) {
 
 	if !s.eventHandler.Fd.IsOpen() {
-		return -1, errors.New("cannot nextPacketInto() on closed capture source")
+		return -1, capture.ErrCaptureStopped
 	}
 
 retry:
@@ -331,7 +331,7 @@ retry:
 func (s *Source) nextPayloadInto(data capture.IPLayer) (int, capture.PacketType, uint32, error) {
 
 	if !s.eventHandler.Fd.IsOpen() {
-		return -1, capture.PacketUnknown, 0, errors.New("cannot nextPacketInto() on closed capture source")
+		return -1, capture.PacketUnknown, 0, capture.ErrCaptureStopped
 	}
 
 retry:

--- a/capture/afpacket/socket/socket_mock.go
+++ b/capture/afpacket/socket/socket_mock.go
@@ -126,6 +126,10 @@ func (m *MockFileDescriptor) Get() capture.Packet {
 	return <-m.buf
 }
 
+func (m *MockFileDescriptor) HasPackets() bool {
+	return len(m.buf) > 0
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
 
 func read(fd int, p []byte) (int, unix.Errno) {

--- a/capture/pcap/pcap_test.go
+++ b/capture/pcap/pcap_test.go
@@ -131,7 +131,7 @@ func TestMockPipe(t *testing.T) {
 			afring.CaptureLength(link.CaptureLengthMinimalIPv4Transport),
 		)
 		require.Nil(t, err)
-		errChan := mockSrc.Pipe(src)
+		errChan := mockSrc.Pipe(src, nil)
 
 		for i := 0; i < pcapTestInputNPackets; i++ {
 			p, err := mockSrc.NextPacket(nil)

--- a/event/poll_mock.go
+++ b/event/poll_mock.go
@@ -48,6 +48,11 @@ func (m *MockHandler) SignalAvailableData() error {
 	return m.write([]byte{1, 0, 0, 0, 0, 0, 0, 0})
 }
 
+// HasPackets returns if there are packets in the underlying mock socket
+func (m *MockHandler) HasPackets() bool {
+	return m.mockFd.HasPackets()
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 func (m *MockHandler) write(data []byte) error {


### PR DESCRIPTION
This adds race-free feedback about data being consumed from the initial source during a `Pipe()` operation (mostly to be used in E2E tests for https://github.com/els0r/goProbe/issues/88). In addition it fixes a few race conditions with the plain afpacket source for completeness and extends testing.

Closes #37 