### PR TITLE
[feature] Remove unnecessary allocation in ring buffer block retrieval

### DIFF
--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -65,8 +65,10 @@ func NewMockSource(iface string, options ...Option) (*MockSource, error) {
 				Flags:        net.FlagUp,
 			},
 		},
-		Mutex:        sync.Mutex{},
-		ringBuffer:   ringBuffer{},
+		Mutex: sync.Mutex{},
+		ringBuffer: ringBuffer{
+			curTPacketHeader: new(tPacketHeader),
+		},
 		eventHandler: mockHandler,
 	}
 


### PR DESCRIPTION
@els0r A tiny improvement that makes the whole capture routine via `afring` completely free of allocations (except initial setup of course).

Closes #43 