### PR TITLE
[feature][bugfix] Remove Free() method and merge into Close()

### DIFF
--- a/capture/afpacket/afpacket/afpacket.go
+++ b/capture/afpacket/afpacket/afpacket.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/fako1024/slimcap/capture"
@@ -268,19 +269,10 @@ func (s *Source) Close() error {
 		return err
 	}
 
-	return nil
-}
-
-// Free releases any pending resources from the capture source (must be called after Close())
-func (s *Source) Free() error {
-	if s == nil {
-		return errors.New("cannot call Free() on nil capture source")
+	// Wait until the file descriptor is closed
+	for s.eventHandler.Fd.IsOpen() {
+		time.Sleep(10 * time.Millisecond)
 	}
-	if !s.eventHandler.Fd.IsOpen() {
-		return errors.New("cannot call Free() on open capture source, call Close() first")
-	}
-
-	s.buf = nil
 
 	return nil
 }

--- a/capture/afpacket/afpacket/afpacket.go
+++ b/capture/afpacket/afpacket/afpacket.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 	"unsafe"
 
 	"github.com/fako1024/slimcap/capture"
@@ -267,11 +266,6 @@ func (s *Source) Close() error {
 
 	if err := s.eventHandler.Fd.Close(); err != nil {
 		return err
-	}
-
-	// Wait until the file descriptor is closed
-	for s.eventHandler.Fd.IsOpen() {
-		time.Sleep(10 * time.Millisecond)
 	}
 
 	return nil

--- a/capture/afpacket/afring/afring.go
+++ b/capture/afpacket/afring/afring.go
@@ -346,10 +346,7 @@ fetch:
 				s.unblocked = false
 			}
 
-			// If the file descriptor / socket is closed then so is the capture
-			if !s.eventHandler.Fd.IsOpen() {
-				return capture.ErrCaptureStopped
-			}
+			// Run a PPOLL on the file descriptor, fetching a new block into the ring buffer
 			efdHasEvent, errno := s.eventHandler.Poll(unix.POLLIN | unix.POLLERR)
 
 			// If an event was received, ensure that the respective error is returned

--- a/capture/afpacket/afring/afring.go
+++ b/capture/afpacket/afring/afring.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 	"unsafe"
 
 	"github.com/fako1024/slimcap/capture"
@@ -307,11 +306,6 @@ func (s *Source) close() error {
 	}
 	if err := s.eventHandler.Fd.Close(); err != nil {
 		return err
-	}
-
-	// Wait until the file descriptor is closed
-	for s.eventHandler.Fd.IsOpen() {
-		time.Sleep(10 * time.Millisecond)
 	}
 
 	return nil

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -287,14 +287,7 @@ func (m *MockSource) Close() error {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	return m.Source.Close()
-}
-
-// Free releases any pending resources from the capture source (must be called after Close())
-func (m *MockSource) Free() error {
-	for m.MockFd.IsOpen() {
-		time.Sleep(10 * time.Millisecond)
-	}
-	m.ringBuffer.ring = nil
-	return nil
+	// Close the capture source (but skip the unmap() operation as it would fail
+	// on the conventional ring buffer slice)
+	return m.Source.close()
 }

--- a/capture/afpacket/afring/afring_mock_nodrain.go
+++ b/capture/afpacket/afring/afring_mock_nodrain.go
@@ -49,12 +49,12 @@ func NewMockSourceNoDrain(iface string, options ...Option) (*MockSourceNoDrain, 
 // mock buffer without consuming it and with minimal overhead from handling the mock socket / semaphore
 // It is intended to be used in benchmarks using the mock source to minimize measurement noise from the
 // mock implementation itself
-func (m *MockSourceNoDrain) Run(releaseInterval time.Duration) (error, <-chan error) {
+func (m *MockSourceNoDrain) Run(releaseInterval time.Duration) (<-chan error, error) {
 
 	// Sweep through all blocks and check if they have been populated
 	for i := 0; i < m.nBlocks; i++ {
 		if m.getBlockStatus(i) != unix.TP_STATUS_CSUMNOTREADY {
-			return ErrMockBufferNotPopulated, nil
+			return nil, ErrMockBufferNotPopulated
 		}
 	}
 
@@ -92,7 +92,7 @@ func (m *MockSourceNoDrain) Run(releaseInterval time.Duration) (error, <-chan er
 		}
 	}(errChan)
 
-	return nil, errChan
+	return errChan, nil
 }
 
 // Done notifies the mock source that no more mock packets will be added, causing the ring buffer

--- a/capture/afpacket/afring/afring_mock_nodrain.go
+++ b/capture/afpacket/afring/afring_mock_nodrain.go
@@ -62,7 +62,7 @@ func (m *MockSourceNoDrain) Run(releaseInterval time.Duration) <-chan error {
 		for {
 			for i := 0; i < m.nBlocks; i++ {
 
-				// If the mocks source is closing retun
+				// If the mock source is closing return
 				if m.closing.Load() {
 					m.doneClosing <- struct{}{}
 					errs <- nil
@@ -94,5 +94,7 @@ func (m *MockSourceNoDrain) Close() error {
 	// Ensure that the Run() routine has terminated to avoid a race condition
 	<-m.doneClosing
 
-	return m.Source.Close()
+	// Close the capture source (but skip the unmap() operation as it would fail
+	// on the conventional ring buffer slice)
+	return m.Source.close()
 }

--- a/capture/afpacket/afring/afring_test.go
+++ b/capture/afpacket/afring/afring_test.go
@@ -131,7 +131,7 @@ func TestClosedSourceNoDrain(t *testing.T) {
 	require.Nil(t, err)
 
 	// Initial attempt without data should fail
-	err, errChan := mockSrc.Run(time.Millisecond)
+	errChan, err := mockSrc.Run(time.Millisecond)
 	require.ErrorIs(t, err, ErrMockBufferNotPopulated)
 	require.Nil(t, errChan)
 
@@ -147,7 +147,7 @@ func TestClosedSourceNoDrain(t *testing.T) {
 	for mockSrc.CanAddPackets() {
 		require.Nil(t, mockSrc.AddPacket(p))
 	}
-	err, errChan = mockSrc.Run(time.Millisecond)
+	errChan, err = mockSrc.Run(time.Millisecond)
 	require.Nil(t, err)
 
 	// Close it right away

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -143,9 +143,6 @@ type Source interface {
 
 	// Close stops / closes the capture source
 	Close() error
-
-	// Free releases any pending resources from the capture source (must be called after Close())
-	Free() error
 }
 
 // SourceZeroCopy denotes a generic packet capture source that supports zero-copy operations

--- a/capture/pcap/pcap.go
+++ b/capture/pcap/pcap.go
@@ -175,11 +175,6 @@ func (s *Source) Close() error {
 	if s.gzipReader != nil {
 		return s.gzipReader.Close()
 	}
-	return nil
-}
-
-// Free releases any pending resources from the capture source (must be called after Close())
-func (s *Source) Free() error {
 	s.buf = nil
 	return nil
 }

--- a/capture/pcap/pcap_test.go
+++ b/capture/pcap/pcap_test.go
@@ -109,7 +109,6 @@ func TestReader(t *testing.T) {
 		require.Equal(t, capture.Stats{PacketsReceived: pcapTestInputNPackets}, stats)
 
 		require.Nil(t, src.Close())
-		require.Nil(t, src.Free())
 	}
 
 }

--- a/examples/dump/main.go
+++ b/examples/dump/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/fako1024/slimcap/capture/afpacket/afring"
 	"github.com/fako1024/slimcap/link"
@@ -75,10 +74,6 @@ func main() {
 
 	if err := listener.Close(); err != nil {
 		logger.Fatalf("failed to close listener on `%s`: %s", devName, err)
-	}
-	time.Sleep(time.Second)
-	if err := listener.Free(); err != nil {
-		logger.Fatalf("failed to free listener resources on `%s`: %s", devName, err)
 	}
 
 	return

--- a/examples/pcap/main.go
+++ b/examples/pcap/main.go
@@ -46,9 +46,6 @@ func main() {
 		if err := listener.Close(); err != nil {
 			logger.Fatalf("failed to close listener on `%s`: %s", fileName, err)
 		}
-		if err := listener.Free(); err != nil {
-			logger.Fatalf("failed to free listener resources on `%s`: %s", fileName, err)
-		}
 	}()
 
 	logger.Infof("Reading up to %d packets from `%s` (link type: %d)...", maxPkts, fileName, listener.Link().Type)


### PR DESCRIPTION
Removes the whole asynchronous process of `Close()` -> `Free()` and replaces it with a single, sequential set of actions inside `Close()`. Once it returns, the capture is closed. Concurrent accesses (e.g. from a `process()` goroutine do not have to be synchronized as the call for the next packet will simply fail (as expected, with `ErrCaptureClosed`) and hence can be handled accordingly without the need for any further synchronization.

Required changes in https://github.com/els0r/goProbe/issues/126 will follow once this is approved / merged.

Closes #48 