### PR TITLE
[feature] Remove expensive net.Interface lookups upon link initialization

### DIFF
--- a/capture/afpacket/afpacket/afpacket.go
+++ b/capture/afpacket/afpacket/afpacket.go
@@ -52,7 +52,7 @@ func NewSource(iface string, options ...Option) (*Source, error) {
 func NewSourceFromLink(link *link.Link, options ...Option) (*Source, error) {
 
 	// Fail if link is not up
-	if !link.IsUp() {
+	if isUp, err := link.IsUp(); err != nil || !isUp {
 		return nil, fmt.Errorf("link %s is not up", link.Name)
 	}
 
@@ -60,7 +60,7 @@ func NewSourceFromLink(link *link.Link, options ...Option) (*Source, error) {
 	src := &Source{
 		eventHandler:  new(event.Handler),
 		snapLen:       DefaultSnapLen,
-		ipLayerOffset: link.Type.IpHeaderOffset(),
+		ipLayerOffset: link.Type.IPHeaderOffset(),
 		link:          link,
 		Mutex:         sync.Mutex{},
 	}

--- a/capture/afpacket/afpacket/afpacket_mock.go
+++ b/capture/afpacket/afpacket/afpacket_mock.go
@@ -3,8 +3,6 @@ package afpacket
 import (
 	"errors"
 	"io"
-	"net"
-	"sync"
 	"time"
 
 	"github.com/fako1024/slimcap/capture"
@@ -77,19 +75,9 @@ func NewMockSource(iface string, options ...Option) (*MockSource, error) {
 
 	src := &Source{
 		snapLen:       DefaultSnapLen,
-		ipLayerOffset: link.TypeEthernet.IpHeaderOffset(),
-		link: &link.Link{
-			Type: link.TypeEthernet,
-			Interface: &net.Interface{
-				Index:        1,
-				MTU:          1500,
-				Name:         iface,
-				HardwareAddr: []byte{},
-				Flags:        net.FlagUp,
-			},
-		},
-		Mutex:        sync.Mutex{},
-		eventHandler: mockHandler,
+		ipLayerOffset: link.TypeEthernet.IPHeaderOffset(),
+		link:          &link.EmptyEthernetLink,
+		eventHandler:  mockHandler,
 	}
 
 	for _, opt := range options {

--- a/capture/afpacket/afpacket/afpacket_test.go
+++ b/capture/afpacket/afpacket/afpacket_test.go
@@ -148,7 +148,7 @@ func TestCaptureMethods(t *testing.T) {
 	t.Run("NextPacketFn", func(t *testing.T) {
 		testCaptureMethods(t, func(t *testing.T, src *MockSource, i, j uint16) {
 			err := src.NextPacketFn(func(payload []byte, totalLen uint32, pktType, ipLayerOffset byte) error {
-				require.Equal(t, src.link.Type.IpHeaderOffset(), ipLayerOffset)
+				require.Equal(t, src.link.Type.IPHeaderOffset(), ipLayerOffset)
 				require.Equal(t, uint32(i+j), totalLen)
 				require.Equal(t, byte(i+j)%5, pktType)
 				require.Equal(t, fmt.Sprintf("1.2.3.%d:%d => 4.5.6.%d:%d (proto: %d)", i%254+1, i, j%254+1, j, 6), capture.IPLayer(payload[ipLayerOffset:]).String())

--- a/capture/afpacket/afring/afring.go
+++ b/capture/afpacket/afring/afring.go
@@ -67,7 +67,7 @@ func NewSource(iface string, options ...Option) (*Source, error) {
 func NewSourceFromLink(link *link.Link, options ...Option) (*Source, error) {
 
 	// Fail if link is not up
-	if !link.IsUp() {
+	if isUp, err := link.IsUp(); err != nil || !isUp {
 		return nil, fmt.Errorf("link %s is not up", link.Name)
 	}
 
@@ -77,7 +77,7 @@ func NewSourceFromLink(link *link.Link, options ...Option) (*Source, error) {
 		snapLen:       DefaultSnapLen,
 		blockSize:     tPacketDefaultBlockSize,
 		nBlocks:       tPacketDefaultBlockNr,
-		ipLayerOffset: link.Type.IpHeaderOffset(),
+		ipLayerOffset: link.Type.IPHeaderOffset(),
 		link:          link,
 		Mutex:         sync.Mutex{},
 	}

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -3,8 +3,6 @@ package afring
 import (
 	"errors"
 	"io"
-	"net"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -54,18 +52,8 @@ func NewMockSource(iface string, options ...Option) (*MockSource, error) {
 		blockSize: tPacketDefaultBlockSize,
 		nBlocks:   tPacketDefaultBlockNr,
 
-		ipLayerOffset: link.TypeEthernet.IpHeaderOffset(),
-		link: &link.Link{
-			Type: link.TypeEthernet,
-			Interface: &net.Interface{
-				Index:        1,
-				MTU:          1500,
-				Name:         iface,
-				HardwareAddr: []byte{},
-				Flags:        net.FlagUp,
-			},
-		},
-		Mutex: sync.Mutex{},
+		ipLayerOffset: link.TypeEthernet.IPHeaderOffset(),
+		link:          &link.EmptyEthernetLink,
 		ringBuffer: ringBuffer{
 			curTPacketHeader: new(tPacketHeader),
 		},

--- a/capture/afpacket/afring/afring_test.go
+++ b/capture/afpacket/afring/afring_test.go
@@ -315,7 +315,7 @@ func TestCaptureMethods(t *testing.T) {
 	t.Run("NextPacketFn", func(t *testing.T) {
 		testCaptureMethods(t, func(t *testing.T, src *MockSource, i, j uint16) {
 			err := src.NextPacketFn(func(payload []byte, totalLen uint32, pktType, ipLayerOffset byte) error {
-				require.Equal(t, src.link.Type.IpHeaderOffset(), ipLayerOffset)
+				require.Equal(t, src.link.Type.IPHeaderOffset(), ipLayerOffset)
 				require.Equal(t, int(i*1000+j), int(totalLen))
 				require.Equal(t, byte(i+j)%5, pktType)
 				require.Equal(t, fmt.Sprintf("1.2.3.%d:%d => 4.5.6.%d:%d (proto: %d)", i%254+1, i, j%254+1, j, 6), capture.IPLayer(payload[ipLayerOffset:]).String())

--- a/capture/pcap/pcap.go
+++ b/capture/pcap/pcap.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"unsafe"
@@ -69,13 +68,12 @@ func NewSource(iface string, r io.Reader) (*Source, error) {
 
 	// Populate (fake) link information
 	obj.link = &link.Link{
-		Type: link.Type(obj.header.Network),
-		Interface: &net.Interface{
-			Name:  iface,
-			Flags: net.FlagUp,
+		Interface: link.Interface{
+			Name: iface,
+			Type: link.Type(obj.header.Network),
 		},
 	}
-	obj.ipLayerOffset = obj.link.Type.IpHeaderOffset()
+	obj.ipLayerOffset = obj.link.Type.IPHeaderOffset()
 
 	return &obj, nil
 }

--- a/capture/pcap/pcap_test.go
+++ b/capture/pcap/pcap_test.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"io"
 	"io/fs"
-	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -71,10 +70,9 @@ func TestReader(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Equal(t, &link.Link{
-			Type: link.TypeEthernet,
-			Interface: &net.Interface{
-				Name:  "pcap",
-				Flags: net.FlagUp,
+			Interface: link.Interface{
+				Name: "pcap",
+				Type: link.TypeEthernet,
 			},
 		}, src.Link())
 
@@ -99,7 +97,7 @@ func TestReader(t *testing.T) {
 			require.Nil(t, payload)
 			require.Zero(t, totalLen)
 			require.Equal(t, capture.PacketUnknown, pktType)
-			require.Equal(t, src.Link().Type.IpHeaderOffset(), ipLayerOffset)
+			require.Equal(t, src.Link().Type.IPHeaderOffset(), ipLayerOffset)
 			return nil
 		})
 		require.ErrorIs(t, err, io.EOF)
@@ -232,7 +230,7 @@ func TestCaptureMethods(t *testing.T) {
 	t.Run("NextPacketFn", func(t *testing.T) {
 		testCaptureMethods(t, func(t *testing.T, src *Source) {
 			err := src.NextPacketFn(func(payload []byte, totalLen uint32, pktType, ipLayerOffset byte) error {
-				require.Equal(t, src.link.Type.IpHeaderOffset(), ipLayerOffset)
+				require.Equal(t, src.link.Type.IPHeaderOffset(), ipLayerOffset)
 				require.NotNil(t, payload)
 				require.Equal(t, capture.PacketUnknown, pktType)
 				require.NotZero(t, totalLen)

--- a/examples/trace/trace.go
+++ b/examples/trace/trace.go
@@ -98,7 +98,7 @@ func (c *Capture) Run() (err error) {
 		return err
 	}
 	for _, iface := range links {
-		logger.Infof("Found interface `%s` (idx %d), link type %d, HWAddr `%s`, flags `%s`", iface.Name, iface.Index, iface.Type, iface.HardwareAddr, iface.Flags)
+		logger.Infof("Found interface `%s` (idx %d), link type %d", iface.Name, iface.Index, iface.Type)
 	}
 
 	// construct list of skipped interfaces
@@ -168,7 +168,7 @@ func (c *Capture) Run() (err error) {
 				}
 			}
 
-			if !l.IsUp() {
+			if isUp, err := l.IsUp(); err != nil || !isUp {
 				logger.Warnf("skipping listener on non-up interface `%s`", l.Name)
 				return
 			}

--- a/link/interface.go
+++ b/link/interface.go
@@ -1,0 +1,29 @@
+package link
+
+// Interface is the low-level representation of a network interface
+type Interface struct {
+	Name  string
+	Index int
+	Type  Type
+}
+
+// NewInterface instantiates a new network interface and obtains its basic parameters
+func NewInterface(name string) (iface Interface, err error) {
+	iface = Interface{
+		Name: name,
+	}
+
+	if iface.Index, err = getIndex(name); err != nil {
+		return
+	}
+	if iface.Type, err = getLinkType(name); err != nil {
+		return
+	}
+
+	return
+}
+
+// String returns the name of the network interface (Stringer interface)
+func (i Interface) String() string {
+	return i.Name
+}

--- a/link/interface_linux.go
+++ b/link/interface_linux.go
@@ -4,7 +4,9 @@
 package link
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,6 +20,9 @@ const (
 	netTypePath  = "/type"
 	netFlagsPath = "/flags"
 )
+
+// ErrIndexOutOfBounds denotes the (unlikely) case of an invalid index being outside the range of an int
+var ErrIndexOutOfBounds = errors.New("interface index out of bounds")
 
 // Interfaces returns all host interfaces
 func Interfaces() ([]Interface, error) {
@@ -74,7 +79,12 @@ func getIndex(name string) (int, error) {
 		return -1, err
 	}
 
-	return int(index), nil
+	// Validate integer upper / lower bounds
+	if index > 0 && index <= math.MaxInt {
+		return int(index), nil
+	}
+
+	return -1, ErrIndexOutOfBounds
 }
 
 func getLinkType(name string) (Type, error) {

--- a/link/interface_linux.go
+++ b/link/interface_linux.go
@@ -1,0 +1,99 @@
+//go:build linux
+// +build linux
+
+package link
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const (
+	netBasePath  = "/sys/class/net/"
+	netIndexPath = "/ifindex"
+	netTypePath  = "/type"
+	netFlagsPath = "/flags"
+)
+
+// Interfaces returns all host interfaces
+func Interfaces() ([]Interface, error) {
+
+	linkDir, err := os.OpenFile(netBasePath, os.O_RDONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	ifaceNames, err := linkDir.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	ifaces := make([]Interface, len(ifaceNames))
+	for i, ifaceName := range ifaceNames {
+		if ifaces[i], err = NewInterface(ifaceName); err != nil {
+			return nil, err
+		}
+	}
+
+	return ifaces, nil
+}
+
+// IsUp determines if an interface is currently up (at the time of the call)
+func (i Interface) IsUp() (bool, error) {
+
+	data, err := os.ReadFile(filepath.Clean(netBasePath + i.Name + netFlagsPath))
+	if err != nil {
+		return false, err
+	}
+
+	flags, err := strconv.ParseInt(
+		strings.TrimSpace(string(data)), 0, 64)
+	if err != nil {
+		return false, err
+	}
+
+	return flags&syscall.IFF_UP != 0, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func getIndex(name string) (int, error) {
+
+	data, err := os.ReadFile(filepath.Clean(netBasePath + name + netIndexPath))
+	if err != nil {
+		return -1, err
+	}
+
+	index, err := strconv.ParseInt(
+		strings.TrimSpace(string(data)), 0, 64)
+	if err != nil {
+		return -1, err
+	}
+
+	return int(index), nil
+}
+
+func getLinkType(name string) (Type, error) {
+
+	sysPath := netBasePath + name + netTypePath
+	data, err := os.ReadFile(filepath.Clean(sysPath))
+	if err != nil {
+		return -1, err
+	}
+
+	val, err := strconv.Atoi(
+		strings.TrimSpace(string(data)))
+	if err != nil {
+		return -1, err
+	}
+
+	if val < 0 || val > 65535 {
+		return -1, fmt.Errorf("invalid link type read from `%s`: %d", sysPath, val)
+	}
+
+	return Type(val), nil
+}

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -2,6 +2,7 @@ package link
 
 import (
 	"io/fs"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -281,6 +282,25 @@ func TestNew(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkNewLink(b *testing.B) {
+	b.Run("slimcap", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iface, _ := NewInterface("lo")
+			_ = iface
+		}
+	})
+	b.Run("net.Interface", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iface, _ := net.InterfaceByName("lo")
+			_ = iface
+		}
+	})
 }
 
 type mockInterfaces struct {

--- a/link/snaplen.go
+++ b/link/snaplen.go
@@ -21,24 +21,24 @@ var (
 	// CaptureLengthMinimalIPv4 indicates that the minimal necessary length to
 	// facilitate IPv4 layer analysis should be chosen
 	CaptureLengthMinimalIPv4Header = func(l *Link) int {
-		return int(l.Type.IpHeaderOffset()) + ipv4.HeaderLen // include full IPv4 header
+		return int(l.Type.IPHeaderOffset()) + ipv4.HeaderLen // include full IPv4 header
 	}
 
 	// CaptureLengthMinimalIPv6 indicates that the minimal necessary length to
 	// facilitate IPv6 layer analysis should be chosen
 	CaptureLengthMinimalIPv6Header = func(l *Link) int {
-		return int(l.Type.IpHeaderOffset()) + ipv6.HeaderLen // include full IPv6 header
+		return int(l.Type.IPHeaderOffset()) + ipv6.HeaderLen // include full IPv6 header
 	}
 
 	// CaptureLengthMinimalIPv4Transport indicates that the minimal necessary length to
 	// facilitate IPv4 transport layer analysis should be chosen
 	CaptureLengthMinimalIPv4Transport = func(l *Link) int {
-		return int(l.Type.IpHeaderOffset()) + ipv4.HeaderLen + 14 // include IPv4 transport layer up to TCP flag position
+		return int(l.Type.IPHeaderOffset()) + ipv4.HeaderLen + 14 // include IPv4 transport layer up to TCP flag position
 	}
 
 	// CaptureLengthMinimalIPv6Transport indicates that the minimal necessary length to
 	// facilitate IPv6 transport layer analysis should be chosen
 	CaptureLengthMinimalIPv6Transport = func(l *Link) int {
-		return int(l.Type.IpHeaderOffset()) + ipv6.HeaderLen + 14 // include IPv4 transport layer up to TCP flag position
+		return int(l.Type.IPHeaderOffset()) + ipv6.HeaderLen + 14 // include IPv4 transport layer up to TCP flag position
 	}
 )


### PR DESCRIPTION
This should alleviate the performance issues encountered on hosts with lots of interfaces. The existing call via `net.Interface` causes a full routing table lookup upon _each_ interface initialization (which is of course especially large on hosts with many interfaces, causing a mean amplification effect). Since we do not require the information therein to setup the ring buffer I've simply replaced the existing implementation with my own lookup based on `/sys/class/net` (which I was using to determine the link type before already) so that only the information for the interface in question is accessed an no routing table information is fetched.
This of course means that we'd need a different implementation if we ever support more OSes, but I'm sure that would have been the case anyway (because we can't use `AF_PACKET` anywhere else), plus we could always fall back to `net.Interface` in such cases.

Closes #50 