### PR TITLE
[bugfix] Fix memory alignment panic on ARM devices (mock socket atomic counter)

### DIFF
--- a/event/poll_386.s
+++ b/event/poll_386.s
@@ -1,0 +1,24 @@
+#include "textflag.h"
+
+#define INVOKE_SYSCALL INT $0x80
+#define SYS__PPOLL 0x135
+
+// func pollBlock(fds *unix.PollFd, nfds int) (err syscall.Errno)
+TEXT ·pollBlock(SB),NOSPLIT,$0-12
+	CALL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
+	MOVL	$SYS__PPOLL, AX			// Prepare / perform ppoll() SYSCALL    
+	MOVL	fds+0(FP), BX			// PollFDs parameter
+	MOVL	nfds+4(FP), CX		        // Put nFDs parameter
+	MOVL	$0x0, DX			// Put timeout parameter (set to NULL)
+	MOVL	$0x0, SI                      	// Put sigmask parameter (skip)
+	INVOKE_SYSCALL
+    CMPL    AX, $0xfffff002		        // No error / EINTR
+	JLS     success			        // Jump to success
+	NEGL    AX			// Negate SYSCALL errno
+	MOVL	AX, err+8(FP)			// Store error code in err return value
+	CALL  	runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
+	RET					// Return
+success:
+	MOVL	$0, err+8(FP)			// Store NULL error code in err return value
+	CALL    runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
+	RET					// Return

--- a/event/poll_amd64.s
+++ b/event/poll_amd64.s
@@ -1,5 +1,7 @@
 #include "textflag.h"
 
+#define SYS__PPOLL 0x10f
+
 // func pollBlock(fds *unix.PollFd, nfds int) (err syscall.Errno)
 TEXT ·pollBlock(SB),NOSPLIT,$0-24
 	CALL	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
@@ -7,7 +9,7 @@ TEXT ·pollBlock(SB),NOSPLIT,$0-24
 	MOVQ	nfds+8(FP), SI					// Put nFDs parameter
 	MOVQ	$0x0, DX						// Put timeout parameter (set to NULL)
 	MOVQ	$0x0, R10                      	// Put sigmask parameter (skip)
-	MOVQ	$0x10f, AX						// Prepare / perform ppoll() SYSCALL
+	MOVQ	$SYS__PPOLL, AX					// Prepare / perform ppoll() SYSCALL
 	SYSCALL
 	CMPQ	AX, $0xfffffffffffff002			// No error / EINTR
 	JLS		success							// Jump to success

--- a/event/poll_arm.s
+++ b/event/poll_arm.s
@@ -1,0 +1,24 @@
+#include "textflag.h"
+
+#define SYS__PPOLL 0x150
+
+// func pollBlock(fds *unix.PollFd, nfds int) (err syscall.Errno)
+TEXT ·pollBlock(SB),NOSPLIT,$0-12
+	BL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
+	MOVW	$SYS__PPOLL, R7			// Prepare / perform ppoll() SYSCALL    
+	MOVW	fds+0(FP), R0			// PollFDs parameter
+	MOVW	nfds+4(FP), R1		        // Put nFDs parameter
+	MOVW	$0x0, R2			// Put timeout parameter (set to NULL)
+	MOVW	$0x0, R3                      	// Put sigmask parameter (skip)
+	SWI     $0
+        CMP     $0xfffff002, R0		        // No error / EINTR
+	BLS	success			        // Jump to success
+	RSB     $0, R0, R0			// Negate SYSCALL errno
+	MOVW	R0, err+8(FP)			// Store error code in err return value
+	BL  	runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
+	RET					// Return
+success:
+	MOVW    $0, R0
+	MOVW	R0, err+8(FP)			// Store NULL error code in err return value
+	BL	runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
+	RET					// Return

--- a/event/poll_arm64.s
+++ b/event/poll_arm64.s
@@ -1,5 +1,7 @@
 #include "textflag.h"
 
+#define SYS__PPOLL 0x49
+
 // func pollBlock(fds *unix.PollFd, nfds int) (err syscall.Errno)
 TEXT ·pollBlock(SB),NOSPLIT,$0-24
 	BL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
@@ -7,7 +9,7 @@ TEXT ·pollBlock(SB),NOSPLIT,$0-24
 	MOVD	nfds+8(FP), R1					// Put nFDs parameter
 	MOVD	$0x0, R2						// Put timeout parameter (set to NULL)
 	MOVD	$0x0, R3                      	// Put sigmask parameter (skip)
-	MOVD	$0x49, R8						// Prepare / perform ppoll() SYSCALL
+	MOVD	$SYS__PPOLL, R8					// Prepare / perform ppoll() SYSCALL
 	SVC
 	CMP     $0xfffffffffffff002, R0			// No error / EINTR
 	BLS		success							// Jump to success

--- a/event/poll_asm.go
+++ b/event/poll_asm.go
@@ -1,5 +1,5 @@
-//go:build (linux && amd64) || (linux && arm64) || (linux && arm)
-// +build linux,amd64 linux,arm64 linux,arm
+//go:build (linux && amd64) || (linux && arm64) || (linux && arm) || (linux && 386)
+// +build linux,amd64 linux,arm64 linux,arm linux,386
 
 package event
 

--- a/event/poll_asm.go
+++ b/event/poll_asm.go
@@ -1,5 +1,5 @@
-//go:build (linux && amd64) || (linux && arm64)
-// +build linux,amd64 linux,arm64
+//go:build (linux && amd64) || (linux && arm64) || (linux && arm)
+// +build linux,amd64 linux,arm64 linux,arm
 
 package event
 

--- a/event/poll_default.go
+++ b/event/poll_default.go
@@ -1,5 +1,5 @@
-//go:build linux && !amd64 && !arm64
-// +build linux,!amd64,!arm64
+//go:build linux && !amd64 && !arm64 && !arm
+// +build linux,!amd64,!arm64,!arm
 
 package event
 

--- a/event/poll_default.go
+++ b/event/poll_default.go
@@ -1,5 +1,5 @@
-//go:build linux && !amd64 && !arm64 && !arm
-// +build linux,!amd64,!arm64,!arm
+//go:build linux && !amd64 && !arm64 && !arm && !386
+// +build linux,!amd64,!arm64,!arm,!386
 
 package event
 


### PR DESCRIPTION
@els0r In addition to the fix, the PR provides optimized assembly for the PPOLL Linux syscall on ARM and i386 (couldn't stop myself :rofl:).

Closes #69 