### PR TITLE
[feature] Improve afring throughput using code optimization

### DIFF
--- a/capture/afpacket/afring/afring.go
+++ b/capture/afpacket/afring/afring.go
@@ -268,8 +268,8 @@ func (s *Source) NextPacketFn(fn func(payload []byte, totalLen uint32, pktType c
 	pos := pktHdr.ppos + uint32(hdr.pktMac)
 
 	// #nosec G103
-	return fn(pktHdr.data[pos:pos+*(*uint32)(unsafe.Pointer(&pktHdr.data[pktHdr.ppos+12]))],
-		*(*uint32)(unsafe.Pointer(&pktHdr.data[pktHdr.ppos+16])),
+	return fn(unsafe.Slice(&pktHdr.data[pos], hdr.snaplen),
+		hdr.pktLen,
 		pktHdr.data[pktHdr.ppos+58],
 		s.ipLayerOffset)
 }

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -62,6 +62,7 @@ func NewMockSource(_ string, options ...Option) (*MockSource, error) {
 		},
 		eventHandler: mockHandler,
 	}
+	src.ipLayerOffsetNum = uint32(src.ipLayerOffset)
 
 	for _, opt := range options {
 		opt(src)

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -129,11 +129,13 @@ func (m *MockSource) addPacket(payload []byte, totalLen uint32, pktType, ipLayer
 
 	block := m.ringBuffer.ring[thisBlock*m.blockSize : thisBlock*m.blockSize+m.blockSize]
 
-	*(*uint32)(unsafe.Pointer(&block[m.curBlockPos+12])) = uint32(m.snapLen) // #nosec: G103 // snapLen
-	*(*uint32)(unsafe.Pointer(&block[m.curBlockPos+16])) = totalLen          // #nosec: G103 // totalLen
-	*(*uint32)(unsafe.Pointer(&block[m.curBlockPos+24])) = uint32(mac)       // #nosec: G103 // mac
-	block[m.curBlockPos+58] = pktType                                        // pktType
-	copy(block[m.curBlockPos+mac:m.curBlockPos+mac+m.snapLen], payload)      // payload
+	*(*tPacketHeaderV3)(unsafe.Pointer(&block[m.curBlockPos+12])) = tPacketHeaderV3{
+		snaplen: uint32(m.snapLen),
+		pktLen:  totalLen,
+		pktPos:  mac,
+		pktType: pktType,
+	} // #nosec: G103
+	copy(block[m.curBlockPos+mac:m.curBlockPos+mac+m.snapLen], payload) // payload
 
 	// Ensure that there is no "stray" nextOffset set from a previous perusal of this ring buffer block which
 	// might remain in case the block is finalized

--- a/capture/afpacket/afring/afring_mock_nodrain.go
+++ b/capture/afpacket/afring/afring_mock_nodrain.go
@@ -5,6 +5,7 @@ package afring
 
 import (
 	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -68,6 +69,8 @@ func (m *MockSourceNoDrain) Run(releaseInterval time.Duration) (<-chan error, er
 	m.wgRunning.Add(1)
 	go func(errs chan error) {
 
+		// Minimize scheduler overhead by locking this goroutine to the current thread
+		runtime.LockOSThread()
 		defer func() {
 			close(errs)
 			m.wgRunning.Done()

--- a/capture/afpacket/afring/afring_mock_test.go
+++ b/capture/afpacket/afring/afring_mock_test.go
@@ -499,6 +499,8 @@ func BenchmarkCaptureMethods(b *testing.B) {
 				})
 			}
 		})
+
+		require.Nil(b, mockSrc.Close())
 	}
 }
 

--- a/capture/afpacket/afring/afring_zerocopy.go
+++ b/capture/afpacket/afring/afring_zerocopy.go
@@ -94,7 +94,7 @@ finalize:
 // Procedurally, the method extracts the next packet from either the current block or advances to the next
 // one (fetching / returning its first packet). Using the offset parameter it supports extraction of
 // both the full payload or the IP layer only.
-func (s *Source) NextIPPacketZeroCopy() (ipLayer []byte, pktType capture.PacketType, pktLen uint32, err error) {
+func (s *Source) NextIPPacketZeroCopy() (ipLayer capture.IPLayer, pktType capture.PacketType, pktLen uint32, err error) {
 
 retry:
 	pktHdr := s.curTPacketHeader

--- a/capture/afpacket/afring/afring_zerocopy.go
+++ b/capture/afpacket/afring/afring_zerocopy.go
@@ -1,0 +1,171 @@
+package afring
+
+import (
+	"unsafe"
+
+	"github.com/fako1024/slimcap/capture"
+	"golang.org/x/sys/unix"
+)
+
+// NextPayloadZeroCopy receives the raw payload of the next packet from the source and returns it. The operation is blocking.
+// The returned payload provides direct zero-copy access to the underlying data source (e.g. a ring buffer).
+// Procedurally, the method extracts the next packet from either the current block or advances to the next
+// one (fetching / returning its first packet). Using the offset parameter it supports extraction of
+// both the full payload or the IP layer only.
+func (s *Source) NextPayloadZeroCopy() (payload []byte, pktType capture.PacketType, pktLen uint32, err error) {
+
+retry:
+	pktHdr := s.curTPacketHeader
+
+	// If there is an active block, attempt to simply consume a packet from it
+	if pktHdr.data != nil {
+
+		// If there are more packets remaining (i.e. there is a non-zero next offset), advance
+		// the current position.
+		// According to https://github.com/torvalds/linux/blame/master/net/packet/af_packet.c#L811 the
+		// tp_next_offset field is guaranteed to be zero for the final packet of the block. In addition,
+		// it cannot be zero otherwise (because that would be an invalid block).
+		if nextPos := pktHdr.nextOffset(); nextPos != 0 {
+
+			// Update position of next packet and jump to the end
+			pktHdr.ppos += nextPos
+			goto finalize
+		}
+
+		// If there is no next offset, release the TPacketHeader to the kernel and move on to the next block
+		s.releaseAndAdvance()
+	}
+
+	// Load the data for the block
+	s.loadTPacketHeader()
+
+	// Check if the block is free to access in userland
+	for pktHdr.getStatus()&unix.TP_STATUS_USER == 0 {
+
+		// Run a PPOLL on the file descriptor (waiting for the block to become available)
+		efdHasEvent, errno := s.eventHandler.Poll(unix.POLLIN | unix.POLLERR)
+
+		// If an event was received, ensure that the respective error / code is returned
+		// immediately
+		if efdHasEvent {
+			pktType, err = capture.PacketUnknown, s.handleEvent()
+			return
+		}
+
+		// Handle potential PPOLL errors
+		if errno != 0 {
+			if errno == unix.EINTR {
+				continue
+			}
+			pktType, err = capture.PacketUnknown, handlePollError(errno)
+			return
+		}
+
+		// Handle rare cases of runaway packets (this call will advance to the next block
+		// as a side effect in case of a detection)
+		if s.hasRunawayBlock() {
+			continue
+		}
+	}
+
+	// Set the position of the first packet in this block and jump to end
+	pktHdr.ppos = pktHdr.offsetToFirstPkt()
+
+finalize:
+
+	// Apply filter (if any)
+	if s.filter > 0 && s.filter&pktHdr.data[pktHdr.ppos+58] != 0 {
+		goto retry
+	}
+
+	// Parse the V3 TPacketHeader and the first byte of the payload
+	hdr := pktHdr.parseHeader()
+	pos := pktHdr.ppos + uint32(hdr.pktMac)
+
+	// Return the payload / IP layer subslice & heeader parameters
+	return unsafe.Slice(&pktHdr.data[pos], hdr.snaplen),
+		pktHdr.data[pktHdr.ppos+58],
+		hdr.pktLen, nil
+
+}
+
+// NextIPPacketZeroCopy receives the IP layer of the next packet from the source and returns it. The operation is blocking.
+// The returned IPLayer provides direct zero-copy access to the underlying data source (e.g. a ring buffer).
+// Procedurally, the method extracts the next packet from either the current block or advances to the next
+// one (fetching / returning its first packet). Using the offset parameter it supports extraction of
+// both the full payload or the IP layer only.
+func (s *Source) NextIPPacketZeroCopy() (ipLayer []byte, pktType capture.PacketType, pktLen uint32, err error) {
+
+retry:
+	pktHdr := s.curTPacketHeader
+
+	// If there is an active block, attempt to simply consume a packet from it
+	if pktHdr.data != nil {
+
+		// If there are more packets remaining (i.e. there is a non-zero next offset), advance
+		// the current position.
+		// According to https://github.com/torvalds/linux/blame/master/net/packet/af_packet.c#L811 the
+		// tp_next_offset field is guaranteed to be zero for the final packet of the block. In addition,
+		// it cannot be zero otherwise (because that would be an invalid block).
+		if nextPos := pktHdr.nextOffset(); nextPos != 0 {
+
+			// Update position of next packet and jump to the end
+			pktHdr.ppos += nextPos
+			goto finalize
+		}
+
+		// If there is no next offset, release the TPacketHeader to the kernel and move on to the next block
+		s.releaseAndAdvance()
+	}
+
+	// Load the data for the block
+	s.loadTPacketHeader()
+
+	// Check if the block is free to access in userland
+	for pktHdr.getStatus()&unix.TP_STATUS_USER == 0 {
+
+		// Run a PPOLL on the file descriptor (waiting for the block to become available)
+		efdHasEvent, errno := s.eventHandler.Poll(unix.POLLIN | unix.POLLERR)
+
+		// If an event was received, ensure that the respective error / code is returned
+		// immediately
+		if efdHasEvent {
+			pktType, err = capture.PacketUnknown, s.handleEvent()
+			return
+		}
+
+		// Handle potential PPOLL errors
+		if errno != 0 {
+			if errno == unix.EINTR {
+				continue
+			}
+			pktType, err = capture.PacketUnknown, handlePollError(errno)
+			return
+		}
+
+		// Handle rare cases of runaway packets (this call will advance to the next block
+		// as a side effect in case of a detection)
+		if s.hasRunawayBlock() {
+			continue
+		}
+	}
+
+	// Set the position of the first packet in this block and jump to end
+	pktHdr.ppos = pktHdr.offsetToFirstPkt()
+
+finalize:
+
+	// Apply filter (if any)
+	if s.filter > 0 && s.filter&pktHdr.data[pktHdr.ppos+58] != 0 {
+		goto retry
+	}
+
+	// Parse the V3 TPacketHeader and the first byte of the payload
+	hdr := pktHdr.parseHeader()
+	pos := pktHdr.ppos + uint32(hdr.pktNet)
+
+	// Extract the payload (zero-copy) & parameters
+	return unsafe.Slice(&pktHdr.data[pos], hdr.snaplen-s.ipLayerOffsetNum),
+		pktHdr.data[pktHdr.ppos+58],
+		hdr.pktLen, nil
+}

--- a/capture/afpacket/afring/afring_zerocopy.go
+++ b/capture/afpacket/afring/afring_zerocopy.go
@@ -10,8 +10,7 @@ import (
 // NextPayloadZeroCopy receives the raw payload of the next packet from the source and returns it. The operation is blocking.
 // The returned payload provides direct zero-copy access to the underlying data source (e.g. a ring buffer).
 // Procedurally, the method extracts the next packet from either the current block or advances to the next
-// one (fetching / returning its first packet). Using the offset parameter it supports extraction of
-// both the full payload or the IP layer only.
+// one (fetching / returning its first packet).
 func (s *Source) NextPayloadZeroCopy() (payload []byte, pktType capture.PacketType, pktLen uint32, err error) {
 
 retry:
@@ -92,8 +91,7 @@ finalize:
 // NextIPPacketZeroCopy receives the IP layer of the next packet from the source and returns it. The operation is blocking.
 // The returned IPLayer provides direct zero-copy access to the underlying data source (e.g. a ring buffer).
 // Procedurally, the method extracts the next packet from either the current block or advances to the next
-// one (fetching / returning its first packet). Using the offset parameter it supports extraction of
-// both the full payload or the IP layer only.
+// one (fetching / returning its first packet IP layer).
 func (s *Source) NextIPPacketZeroCopy() (ipLayer capture.IPLayer, pktType capture.PacketType, pktLen uint32, err error) {
 
 retry:

--- a/capture/afpacket/afring/ring.go
+++ b/capture/afpacket/afring/ring.go
@@ -1,0 +1,33 @@
+//go:build linux
+// +build linux
+
+package afring
+
+import "golang.org/x/sys/unix"
+
+type ringBuffer struct {
+	ring []byte
+
+	tpReq            tPacketRequest
+	curTPacketHeader *tPacketHeader
+	offset           int
+}
+
+func (b *ringBuffer) releaseAndAdvance() {
+	b.curTPacketHeader.setStatus(unix.TP_STATUS_KERNEL)
+	b.offset = (b.offset + 1) % int(b.tpReq.blockNr)
+}
+
+func (b *ringBuffer) loadTPacketHeader() {
+	b.curTPacketHeader.data = b.ring[b.offset*int(b.tpReq.blockSize):]
+}
+
+func (b *ringBuffer) hasRunawayBlock() bool {
+	if b.curTPacketHeader.getStatus()&unix.TP_STATUS_COPY != 0 {
+		b.releaseAndAdvance()
+		b.curTPacketHeader.data = nil
+		return true
+	}
+
+	return false
+}

--- a/capture/afpacket/afring/tpacket.go
+++ b/capture/afpacket/afring/tpacket.go
@@ -102,8 +102,8 @@ type tPacketHeaderV3 struct {
 	snaplen uint32     // 12-16
 	pktLen  uint32     // 16-20
 	_       uint32     // skip
-	pktPos  uint32     // 24-28
-	_       [15]uint16 // skip
+	pktPos  uint16     // 24-26
+	_       [16]uint16 // skip
 	pktType byte       // 58
 }
 
@@ -131,7 +131,7 @@ func (t tPacketHeader) payloadZeroCopy(offset byte) ([]byte, byte, uint32) {
 
 	// Parse the V3 TPacketHeader and the first byte of the payload
 	hdr := (*tPacketHeaderV3)(unsafe.Pointer(&t.data[t.ppos+12])) // #nosec G103
-	pos := t.ppos + hdr.pktPos + uint32(offset)
+	pos := t.ppos + uint32(hdr.pktPos) + uint32(offset)
 
 	// Return the payload / IP layer subslice & heeader parameters
 	return t.data[pos : pos+hdr.snaplen],
@@ -143,7 +143,7 @@ func (t tPacketHeader) packetPut(data capture.Packet, ipLayerOffset byte) captur
 
 	// Parse the V3 TPacketHeader, the first byte of the payload and snaplen
 	hdr := (*tPacketHeaderV3)(unsafe.Pointer(&t.data[t.ppos+12])) // #nosec G103
-	pos := t.ppos + hdr.pktPos
+	pos := t.ppos + uint32(hdr.pktPos)
 	snapLen := int(hdr.snaplen)
 
 	// Allocate new capture.Packet if no buffer was provided
@@ -169,7 +169,7 @@ func (t tPacketHeader) payloadPut(data []byte, offset byte) ([]byte, capture.Pac
 
 	// Parse the V3 TPacketHeader, the first byte of the payload and snaplen
 	hdr := (*tPacketHeaderV3)(unsafe.Pointer(&t.data[t.ppos+12])) // #nosec G103
-	pos := t.ppos + hdr.pktPos + uint32(offset)
+	pos := t.ppos + uint32(hdr.pktPos) + uint32(offset)
 	snapLen := int(hdr.snaplen)
 
 	// Allocate new payload / IP layer if no buffer was provided

--- a/event/event_mock_test.go
+++ b/event/event_mock_test.go
@@ -5,7 +5,6 @@ package event
 
 import (
 	"errors"
-	"syscall"
 	"testing"
 	"time"
 
@@ -57,13 +56,13 @@ func TestPollOnClosedFD(t *testing.T) {
 
 	efdHasEvent, errno := handler.Poll(unix.POLLIN | unix.POLLERR)
 	require.True(t, efdHasEvent)
-	require.Equal(t, syscall.Errno(0x0), errno)
+	require.Equal(t, unix.Errno(0x0), errno)
 	_, err = handler.Efd.ReadEvent()
 	require.Nil(t, err)
 
 	for i := 0; i < 10; i++ {
 		efdHasEvent, errno := handler.Poll(unix.POLLIN | unix.POLLERR)
 		require.False(t, efdHasEvent)
-		require.Equal(t, syscall.Errno(0x9), errno)
+		require.Equal(t, unix.Errno(0x9), errno)
 	}
 }

--- a/event/poll.go
+++ b/event/poll.go
@@ -9,7 +9,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const nPollEvents = 2
+const (
+	eventPollIn    = unix.POLLIN
+	eventConnReset = unix.POLLHUP | unix.POLLERR
+)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -28,17 +31,4 @@ func (p *Handler) recvfrom(buf []byte, flags int) (int, uint8, error) {
 	}
 
 	return n, pktType, nil
-}
-
-func poll(pollEvents [nPollEvents]unix.PollFd) (bool, unix.Errno) {
-	errno := pollBlock(&pollEvents[0], nPollEvents)
-	if errno != 0 {
-		return pollEvents[0].Revents&unix.POLLIN != 0, errno
-	}
-
-	if pollEvents[1].Revents&unix.POLLHUP != 0 || pollEvents[1].Revents&unix.POLLERR != 0 {
-		errno = unix.ECONNRESET
-	}
-
-	return pollEvents[0].Revents&unix.POLLIN != 0, errno
 }

--- a/event/poll_386.s
+++ b/event/poll_386.s
@@ -1,3 +1,5 @@
+// +build !slimcap_noasm
+
 #include "textflag.h"
 
 #define INVOKE_SYSCALL INT $0x80

--- a/event/poll_386.s
+++ b/event/poll_386.s
@@ -4,7 +4,7 @@
 #define SYS__PPOLL 0x135
 #define N_EVTS 0x02
 
-// func pollBlock(fds *unix.PollFd) (err syscall.Errno)
+// func pollBlock(fds *unix.PollFd) (err unix.Errno)
 TEXT ·pollBlock(SB),NOSPLIT,$0-8
 	CALL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
 	MOVL	$SYS__PPOLL, AX			// Prepare / perform ppoll() SYSCALL    

--- a/event/poll_386.s
+++ b/event/poll_386.s
@@ -2,23 +2,24 @@
 
 #define INVOKE_SYSCALL INT $0x80
 #define SYS__PPOLL 0x135
+#define N_EVTS 0x02
 
-// func pollBlock(fds *unix.PollFd, nfds int) (err syscall.Errno)
-TEXT ·pollBlock(SB),NOSPLIT,$0-12
+// func pollBlock(fds *unix.PollFd) (err syscall.Errno)
+TEXT ·pollBlock(SB),NOSPLIT,$0-8
 	CALL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
 	MOVL	$SYS__PPOLL, AX			// Prepare / perform ppoll() SYSCALL    
 	MOVL	fds+0(FP), BX			// PollFDs parameter
-	MOVL	nfds+4(FP), CX		        // Put nFDs parameter
+	MOVL	$N_EVTS, CX		        // Put nFDs parameter (constant N_EVTS)
 	MOVL	$0x0, DX			// Put timeout parameter (set to NULL)
 	MOVL	$0x0, SI                      	// Put sigmask parameter (skip)
 	INVOKE_SYSCALL
 	CMPL    AX, $0xfffff002		        // No error / EINTR
 	JLS     success			        // Jump to success
 	NEGL    AX				// Negate SYSCALL errno
-	MOVL	AX, err+8(FP)			// Store error code in err return value
+	MOVL	AX, err+4(FP)			// Store error code in err return value
 	CALL  	runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
 	RET					// Return
 success:
-	MOVL	$0, err+8(FP)			// Store NULL error code in err return value
+	MOVL	$0, err+4(FP)			// Store NULL error code in err return value
 	CALL    runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
 	RET					// Return

--- a/event/poll_amd64.s
+++ b/event/poll_amd64.s
@@ -3,7 +3,7 @@
 #define SYS__PPOLL 0x10f
 #define N_EVTS 0x02
 
-// func pollBlock(fds *unix.PollFd) (err syscall.Errno)
+// func pollBlock(fds *unix.PollFd) (err unix.Errno)
 TEXT ·pollBlock(SB),NOSPLIT,$0-16
 	CALL	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
 	MOVQ	fds+0(FP), DI					// PollFDs parameter

--- a/event/poll_amd64.s
+++ b/event/poll_amd64.s
@@ -1,3 +1,5 @@
+// +build !slimcap_noasm
+
 #include "textflag.h"
 
 #define SYS__PPOLL 0x10f

--- a/event/poll_amd64.s
+++ b/event/poll_amd64.s
@@ -1,12 +1,13 @@
 #include "textflag.h"
 
 #define SYS__PPOLL 0x10f
+#define N_EVTS 0x02
 
-// func pollBlock(fds *unix.PollFd, nfds int) (err syscall.Errno)
-TEXT ·pollBlock(SB),NOSPLIT,$0-24
+// func pollBlock(fds *unix.PollFd) (err syscall.Errno)
+TEXT ·pollBlock(SB),NOSPLIT,$0-16
 	CALL	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
 	MOVQ	fds+0(FP), DI					// PollFDs parameter
-	MOVQ	nfds+8(FP), SI					// Put nFDs parameter
+	MOVQ	$N_EVTS, SI						// Put nFDs parameter (constant N_EVTS)
 	MOVQ	$0x0, DX						// Put timeout parameter (set to NULL)
 	MOVQ	$0x0, R10                      	// Put sigmask parameter (skip)
 	MOVQ	$SYS__PPOLL, AX					// Prepare / perform ppoll() SYSCALL
@@ -14,10 +15,10 @@ TEXT ·pollBlock(SB),NOSPLIT,$0-24
 	CMPQ	AX, $0xfffffffffffff002			// No error / EINTR
 	JLS		success							// Jump to success
 	NEGQ	AX								// Negate SYSCALL errno
-	MOVQ	AX, err+16(FP)					// Store error code in err return value
+	MOVQ	AX, err+8(FP)					// Store error code in err return value
 	CALL	runtime·exitsyscall(SB)			// Finalize SYSCALL using the directive from runtime package
 	RET										// Return
 success:
-	MOVQ	$0, err+16(FP)					// Store NULL error code in err return value
+	MOVQ	$0, err+8(FP)					// Store NULL error code in err return value
 	CALL	runtime·exitsyscall(SB)			// Finalize SYSCALL using the directive from runtime package
 	RET										// Return

--- a/event/poll_arm.s
+++ b/event/poll_arm.s
@@ -1,3 +1,5 @@
+// +build !slimcap_noasm
+
 #include "textflag.h"
 
 #define SYS__PPOLL 0x150

--- a/event/poll_arm.s
+++ b/event/poll_arm.s
@@ -1,24 +1,25 @@
 #include "textflag.h"
 
 #define SYS__PPOLL 0x150
+#define N_EVTS 0x02
 
-// func pollBlock(fds *unix.PollFd, nfds int) (err syscall.Errno)
-TEXT ·pollBlock(SB),NOSPLIT,$0-12
+// func pollBlock(fds *unix.PollFd) (err syscall.Errno)
+TEXT ·pollBlock(SB),NOSPLIT,$0-8
 	BL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
 	MOVW	$SYS__PPOLL, R7			// Prepare / perform ppoll() SYSCALL    
 	MOVW	fds+0(FP), R0			// PollFDs parameter
-	MOVW	nfds+4(FP), R1		        // Put nFDs parameter
+	MOVW	$N_EVTS, R1		        // Put nFDs parameter (constant N_EVTS)
 	MOVW	$0x0, R2			// Put timeout parameter (set to NULL)
 	MOVW	$0x0, R3                      	// Put sigmask parameter (skip)
 	SWI     $0
         CMP     $0xfffff002, R0		        // No error / EINTR
 	BLS	success			        // Jump to success
 	RSB     $0, R0, R0			// Negate SYSCALL errno
-	MOVW	R0, err+8(FP)			// Store error code in err return value
+	MOVW	R0, err+4(FP)			// Store error code in err return value
 	BL  	runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
 	RET					// Return
 success:
 	MOVW    $0, R0
-	MOVW	R0, err+8(FP)			// Store NULL error code in err return value
+	MOVW	R0, err+4(FP)			// Store NULL error code in err return value
 	BL	runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
 	RET					// Return

--- a/event/poll_arm.s
+++ b/event/poll_arm.s
@@ -3,7 +3,7 @@
 #define SYS__PPOLL 0x150
 #define N_EVTS 0x02
 
-// func pollBlock(fds *unix.PollFd) (err syscall.Errno)
+// func pollBlock(fds *unix.PollFd) (err unix.Errno)
 TEXT ·pollBlock(SB),NOSPLIT,$0-8
 	BL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
 	MOVW	$SYS__PPOLL, R7			// Prepare / perform ppoll() SYSCALL    

--- a/event/poll_arm64.s
+++ b/event/poll_arm64.s
@@ -1,3 +1,5 @@
+// +build !slimcap_noasm
+
 #include "textflag.h"
 
 #define SYS__PPOLL 0x49

--- a/event/poll_arm64.s
+++ b/event/poll_arm64.s
@@ -3,7 +3,7 @@
 #define SYS__PPOLL 0x49
 #define N_EVTS 0x02
 
-// func pollBlock(fds *unix.PollFd) (err syscall.Errno)
+// func pollBlock(fds *unix.PollFd) (err unix.Errno)
 TEXT ·pollBlock(SB),NOSPLIT,$0-16
 	BL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
 	MOVD	fds+0(FP), R0			// PollFDs parameter

--- a/event/poll_arm64.s
+++ b/event/poll_arm64.s
@@ -1,12 +1,13 @@
 #include "textflag.h"
 
 #define SYS__PPOLL 0x49
+#define N_EVTS 0x02
 
-// func pollBlock(fds *unix.PollFd, nfds int) (err syscall.Errno)
-TEXT ·pollBlock(SB),NOSPLIT,$0-24
+// func pollBlock(fds *unix.PollFd) (err syscall.Errno)
+TEXT ·pollBlock(SB),NOSPLIT,$0-16
 	BL  	runtime·entersyscallblock(SB)	// Call blocking SYSCALL directive from runtime package
 	MOVD	fds+0(FP), R0			// PollFDs parameter
-	MOVD	nfds+8(FP), R1			// Put nFDs parameter
+	MOVD	$N_EVTS, R1			// Put nFDs parameter (constant N_EVTS)
 	MOVD	$0x0, R2			// Put timeout parameter (set to NULL)
 	MOVD	$0x0, R3			// Put sigmask parameter (skip)
 	MOVD	$SYS__PPOLL, R8			// Prepare / perform ppoll() SYSCALL
@@ -14,10 +15,10 @@ TEXT ·pollBlock(SB),NOSPLIT,$0-24
 	CMP     $0xfffffffffffff002, R0		// No error / EINTR
 	BLS	success				// Jump to success
 	NEG	R0, R0				// Negate SYSCALL errno
-	MOVD	R0, err+16(FP)			// Store error code in err return value
+	MOVD	R0, err+8(FP)			// Store error code in err return value
 	BL  	runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
 	RET					// Return
 success:
-	MOVD	$0, err+16(FP)			// Store NULL error code in err return value
+	MOVD	$0, err+8(FP)			// Store NULL error code in err return value
 	BL	runtime·exitsyscall(SB)		// Finalize SYSCALL using the directive from runtime package
 	RET					// Return

--- a/event/poll_asm.go
+++ b/event/poll_asm.go
@@ -4,25 +4,22 @@
 package event
 
 import (
-	"golang.org/x/sys/unix"
-
 	_ "unsafe" // required to support go:linkname
+
+	"golang.org/x/sys/unix"
 )
 
 //go:noescape
 //go:nosplit
-func pollBlock(fds *unix.PollFd, nfds int) unix.Errno
+//go:norace
+func pollBlock(fds *unix.PollFd) unix.Errno
 
 ////////////////////////////////////
 
-// The following stubs are required to allow unsafe access to their equivalent in the runtime package from assembly
+// The following stub is required to allow unsafe access to their equivalent in the runtime package from assembly
 // This might break in the future, but there various sources that claim that it's widely used (and even issues at least
 // imply that it's ok to use in favor of exposing that functionality (c.f. https://github.com/golang/go/issues/29734)
 
 //go:linkname entersyscallblock runtime.entersyscallblock
 //go:noescape
 func entersyscallblock() //nolint:deadcode
-
-//go:linkname exitsyscall runtime.exitsyscall
-//go:noescape
-func exitsyscall() //nolint:deadcode

--- a/event/poll_asm.go
+++ b/event/poll_asm.go
@@ -1,5 +1,6 @@
-//go:build (linux && amd64) || (linux && arm64) || (linux && arm) || (linux && 386)
+//go:build ((linux && amd64) || (linux && arm64) || (linux && arm) || (linux && 386)) && !slimcap_noasm
 // +build linux,amd64 linux,arm64 linux,arm linux,386
+// +build !slimcap_noasm
 
 package event
 

--- a/event/poll_default.go
+++ b/event/poll_default.go
@@ -9,11 +9,13 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func pollBlock(fds *unix.PollFd, nfds int) unix.Errno {
+const nPollEvents = uintptr(0x02)
+
+func pollBlock(fds *unix.PollFd) unix.Errno {
 
 	// #nosec: G103
 	_, _, e := unix.Syscall6(unix.SYS_PPOLL, uintptr(unsafe.Pointer(fds)),
-		uintptr(nfds), uintptr(unsafe.Pointer(nil)), 0, 0, 0)
+		nPollEvents, uintptr(unsafe.Pointer(nil)), 0, 0, 0)
 
 	return e
 }

--- a/event/poll_default.go
+++ b/event/poll_default.go
@@ -1,5 +1,5 @@
-//go:build linux && !amd64 && !arm64 && !arm && !386
-// +build linux,!amd64,!arm64,!arm,!386
+//go:build (linux && !amd64 && !arm64 && !arm && !386) || slimcap_noasm
+// +build linux,!amd64,!arm64,!arm,!386 slimcap_noasm
 
 package event
 

--- a/event/poll_mock.go
+++ b/event/poll_mock.go
@@ -26,7 +26,7 @@ type Handler struct {
 
 // Poll polls (blocking, hence no timeout) for events on the file descriptor and the event
 // file descriptor (waiting for a POLLIN event).
-func (p *Handler) Poll(events int16) (bool, unix.Errno) {
+func (p *Handler) Poll(events int16) (hasEvent bool, errno unix.Errno) {
 	pollEvents := [...]unix.PollFd{
 		{
 			Fd:     int32(p.Efd),
@@ -38,21 +38,25 @@ func (p *Handler) Poll(events int16) (bool, unix.Errno) {
 		},
 	}
 
-	// Fast path: If this is not a MockHandler, simply return a regular poll
+	// Perform blocking PPOLL
+	errno = pollBlock(&pollEvents[0])
+	if errno == 0 && pollEvents[1].Revents&eventConnReset != 0 {
+		errno = unix.ECONNRESET
+	}
+	hasEvent = pollEvents[0].Revents&eventPollIn != 0
+
+	// Fast path: If this is not a MockHandler, simply return
 	if p.mockFd == nil {
-		return poll(pollEvents)
+		return
 	}
 
-	// MockHandler logic: Poll, then release the semaphore, indicating data has
+	// MockHandler logic: Release the semaphore, indicating data has
 	// been consumed
-	hasEvent, errno := poll(pollEvents)
 	if !hasEvent && errno == 0 {
-		if errno := p.mockFd.ReleaseSemaphore(); errno != 0 {
-			return false, errno
-		}
+		errno = p.mockFd.ReleaseSemaphore()
 	}
 
-	return hasEvent, errno
+	return
 }
 
 // Recvfrom retrieves data directly from the socket

--- a/examples/dump/main.go
+++ b/examples/dump/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/els0r/telemetry/logging"
+	"github.com/fako1024/slimcap/capture"
 	"github.com/fako1024/slimcap/capture/afpacket/afring"
 	"github.com/fako1024/slimcap/link"
 )
@@ -65,7 +66,7 @@ func main() {
 	logger.Infof("Reading %d packets from wire (zero-copy function call)...", maxPkts)
 	for i := 0; i < maxPkts; i++ {
 		if err := listener.NextPacketFn(func(payload []byte, totalLen uint32, pktType, ipLayerOffset byte) (err error) {
-			logger.Infof("Received packet with Payload on `%s` (total len %d): %v (inbound: %v)", devName, totalLen, payload, p.IsInbound())
+			logger.Infof("Received packet with Payload on `%s` (total len %d): %v (inbound: %v)", devName, totalLen, payload, pktType != capture.PacketOutgoing)
 			return
 		}); err != nil {
 			logger.Fatalf("error during capture (zero-copy function call) on `%s`: %s", devName, err)

--- a/examples/trace/trace.go
+++ b/examples/trace/trace.go
@@ -9,12 +9,12 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/fako1024/slimcap/capture"
 	"github.com/fako1024/slimcap/capture/afpacket/afpacket"
 	"github.com/fako1024/slimcap/capture/afpacket/afring"
 	"github.com/fako1024/slimcap/link"
+	"golang.org/x/sys/unix"
 )
 
 // Capture denotes a simple capturing structure / manager
@@ -163,7 +163,7 @@ func (c *Capture) Run() (err error) {
 	logger.Infof("attempting capture on interfaces [%s]", strings.Join(capturing, ","))
 
 	sigExitChan := make(chan os.Signal, 1)
-	signal.Notify(sigExitChan, syscall.SIGTERM, os.Interrupt)
+	signal.Notify(sigExitChan, unix.SIGTERM, os.Interrupt)
 
 	var listeners []capture.Source
 	// Fork a goroutine for each interface

--- a/link/interface_linux.go
+++ b/link/interface_linux.go
@@ -10,7 +10,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -60,7 +61,7 @@ func (i Interface) IsUp() (bool, error) {
 		return false, err
 	}
 
-	return flags&syscall.IFF_UP != 0, nil
+	return flags&unix.IFF_UP != 0, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@els0r Things done here:

- Instead of performing individual calls / casts via `unsafe` for all data fields, the portion of the TPacketHeaderV3 struct is cast directly (memory-aligned) and then worked with locally
- Compiler inlining is optimized (in the sense that functions are either guaranteed to be inlined by the compiler _or_ they are manually inlined at the expense of a little bit of code duplication on the innermost layers)
- Complete restructuring of the core `PPOLL` loop and handling to focus on fast path (non-poll extraction from current active block) while improving code readability
- Some micro-optimizations to assembly code
- Significant improvements to reproducibility of benchmarks (by means of minimizing scheduler overhead when handling goroutines)
- Fix `NextPayloadInPlace` to actually do what it's supposed to (instead of performing a zero-copy operation, which is why performance is "worse")
- Some minor code cleanup

Benchmarks (on three different systems) further below. The improvements for the non-zero-copy cases are nice to have, but they mostly serve as a consistency check that the performed changes are beneficial across the board (and that no regressions are introduced). Most important are the improvements for the `ZeroCopy` methods, which are in the range of 12-17% (depending on system), which, given the level of optimization we're looking at, is quite a lot:
```
cpu: Intel(R) Core(TM) i3-2100T CPU @ 2.50GHz
CaptureMethods/NextPacket_10485kiBx4-4             103.4n ± 1%   103.3n ± 1%        ~ (p=0.735 n=50)
CaptureMethods/NextPacketInPlace_10485kiBx4-4      40.20n ± 1%   39.94n ± 1%   -0.67% (p=0.043 n=50)
CaptureMethods/NextPayload_10485kiBx4-4            91.19n ± 1%   88.76n ± 1%   -2.66% (p=0.000 n=50)
CaptureMethods/NextPayloadInPlace_10485kiBx4-4     21.56n ± 1%   32.90n ± 3%  +52.57% (p=0.000 n=50)
CaptureMethods/NextPayloadZeroCopy_10485kiBx4-4    19.73n ± 1%   16.38n ± 0%  -16.98% (n=50)
CaptureMethods/NextIPPacket_10485kiBx4-4           91.75n ± 1%   89.80n ± 1%   -2.14% (p=0.000 n=50)
CaptureMethods/NextIPPacketInPlace_10485kiBx4-4    33.33n ± 2%   33.51n ± 2%        ~ (p=0.945 n=50)
CaptureMethods/NextIPPacketZeroCopy_10485kiBx4-4   19.75n ± 1%   16.68n ± 0%  -15.59% (n=50)
CaptureMethods/NextPacketFn_10485kiBx4-4           20.70n ± 1%   19.52n ± 1%   -5.72% (n=50)
CaptureMethods/NextPacket_10kiBx512-4              211.2n ± 1%   214.0n ± 1%   +1.35% (p=0.046 n=50)
CaptureMethods/NextPacketInPlace_10kiBx512-4       210.8n ± 4%   197.1n ± 2%   -6.48% (p=0.000 n=50)
CaptureMethods/NextPayload_10kiBx512-4             190.8n ± 2%   182.6n ± 1%   -4.32% (p=0.000 n=50)
CaptureMethods/NextPayloadInPlace_10kiBx512-4      200.4n ± 2%   195.5n ± 1%        ~ (p=0.058 n=50)
CaptureMethods/NextPayloadZeroCopy_10kiBx512-4     200.8n ± 2%   189.8n ± 2%   -5.48% (p=0.000 n=50)
CaptureMethods/NextIPPacket_10kiBx512-4            189.4n ± 1%   180.1n ± 1%   -4.91% (p=0.000 n=50)
CaptureMethods/NextIPPacketInPlace_10kiBx512-4     203.0n ± 2%   192.9n ± 2%   -4.98% (p=0.000 n=50)
CaptureMethods/NextIPPacketZeroCopy_10kiBx512-4    199.6n ± 2%   177.3n ± 2%  -11.20% (n=50)
CaptureMethods/NextPacketFn_10kiBx512-4            199.1n ± 2%   198.8n ± 4%        ~ (p=0.168 n=50)
```
```
cpu: Intel(R) Celeron(R) N5105 @ 2.00GHz
CaptureMethods/NextPacket_10485kiBx4-4             80.36n ± 0%   79.39n ± 0%   -1.20% (p=0.000 n=50)
CaptureMethods/NextPacketInPlace_10485kiBx4-4      37.06n ± 1%   34.04n ± 1%   -8.16% (p=0.000 n=50)
CaptureMethods/NextPayload_10485kiBx4-4            74.45n ± 0%   68.41n ± 1%   -8.12% (n=50)
CaptureMethods/NextPayloadInPlace_10485kiBx4-4     20.16n ± 0%   29.77n ± 0%  +47.69% (p=0.000 n=50)
CaptureMethods/NextPayloadZeroCopy_10485kiBx4-4    18.32n ± 1%   15.91n ± 0%  -13.15% (n=50)
CaptureMethods/NextIPPacket_10485kiBx4-4           71.47n ± 0%   70.93n ± 0%   -0.75% (p=0.000 n=50)
CaptureMethods/NextIPPacketInPlace_10485kiBx4-4    31.10n ± 1%   31.86n ± 1%   +2.46% (p=0.002 n=50)
CaptureMethods/NextIPPacketZeroCopy_10485kiBx4-4   18.25n ± 0%   16.15n ± 0%  -11.51% (n=50)
CaptureMethods/NextPacketFn_10485kiBx4-4           19.24n ± 0%   21.73n ± 9%        ~ (p=0.051 n=50)
CaptureMethods/NextPacket_10kiBx512-4              128.6n ± 1%   129.5n ± 2%        ~ (p=0.934 n=50)
CaptureMethods/NextPacketInPlace_10kiBx512-4       124.3n ± 0%   122.0n ± 1%   -1.85% (p=0.000 n=50)
CaptureMethods/NextPayload_10kiBx512-4             126.7n ± 1%   122.6n ± 1%   -3.27% (p=0.000 n=50)
CaptureMethods/NextPayloadInPlace_10kiBx512-4      128.9n ± 1%   122.0n ± 1%   -5.39% (p=0.000 n=50)
CaptureMethods/NextPayloadZeroCopy_10kiBx512-4     130.0n ± 1%   126.8n ± 1%   -2.42% (p=0.000 n=50)
CaptureMethods/NextIPPacket_10kiBx512-4            125.0n ± 1%   122.9n ± 1%   -1.64% (p=0.000 n=50)
CaptureMethods/NextIPPacketInPlace_10kiBx512-4     125.0n ± 1%   122.0n ± 1%   -2.44% (p=0.000 n=50)
CaptureMethods/NextIPPacketZeroCopy_10kiBx512-4    129.3n ± 1%   127.3n ± 1%   -1.55% (p=0.000 n=50)
CaptureMethods/NextPacketFn_10kiBx512-4            129.7n ± 1%   124.9n ± 1%   -3.74% (p=0.000 n=50)
```
```
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
CaptureMethods/NextPacket_10485kiBx4-4             54.54n ± 0%   53.58n ± 0%   -1.75% (p=0.000 n=50)
CaptureMethods/NextPacketInPlace_10485kiBx4-4      22.50n ± 1%   22.33n ± 0%   -0.78% (p=0.002 n=50)
CaptureMethods/NextPayload_10485kiBx4-4            48.56n ± 0%   47.34n ± 0%   -2.50% (p=0.000 n=50)
CaptureMethods/NextPayloadInPlace_10485kiBx4-4     13.76n ± 0%   18.67n ± 6%  +35.68% (p=0.000 n=50)
CaptureMethods/NextPayloadZeroCopy_10485kiBx4-4    12.89n ± 0%   11.16n ± 0%  -13.42% (n=50)
CaptureMethods/NextIPPacket_10485kiBx4-4           48.20n ± 0%   47.38n ± 0%   -1.70% (p=0.000 n=50)
CaptureMethods/NextIPPacketInPlace_10485kiBx4-4    19.24n ± 3%   19.57n ± 0%        ~ (p=0.422 n=50)
CaptureMethods/NextIPPacketZeroCopy_10485kiBx4-4   12.84n ± 0%   11.19n ± 0%  -12.85% (n=50)
CaptureMethods/NextPacketFn_10485kiBx4-4           13.40n ± 0%   12.86n ± 0%   -4.03% (n=50)
CaptureMethods/NextPacket_10kiBx512-4              138.4n ± 3%   132.4n ± 2%        ~ (p=0.361 n=50)
CaptureMethods/NextPacketInPlace_10kiBx512-4       155.6n ± 6%   165.1n ± 2%   +6.14% (p=0.010 n=50)
CaptureMethods/NextPayload_10kiBx512-4             149.4n ± 7%   150.7n ± 2%   +0.87% (p=0.016 n=50)
CaptureMethods/NextPayloadInPlace_10kiBx512-4      173.9n ± 5%   165.2n ± 3%        ~ (p=0.622 n=50)
CaptureMethods/NextPayloadZeroCopy_10kiBx512-4     167.4n ± 6%   167.4n ± 4%        ~ (p=0.051 n=50)
CaptureMethods/NextIPPacket_10kiBx512-4            151.2n ± 3%   151.4n ± 4%        ~ (p=0.136 n=50)
CaptureMethods/NextIPPacketInPlace_10kiBx512-4     157.9n ± 5%   162.4n ± 2%   +2.82% (p=0.034 n=50)
CaptureMethods/NextIPPacketZeroCopy_10kiBx512-4    163.1n ± 6%   171.5n ± 3%   +5.12% (p=0.003 n=50)
CaptureMethods/NextPacketFn_10kiBx512-4            168.6n ± 4%   167.1n ± 4%        ~ (p=0.480 n=50)
```

Closes #71 