### PR TITLE
[bugfix] Replace custom direction filter for loopback interfaces with BPF filter

### DIFF
--- a/capture/afpacket/afpacket/afpacket.go
+++ b/capture/afpacket/afpacket/afpacket.go
@@ -222,11 +222,6 @@ retry:
 		return fmt.Errorf("error receiving next packet from socket: %w", err)
 	}
 
-	// Apply filter (if any)
-	if filter := s.link.FilterMask(); filter > 0 && filter&pktType != 0 {
-		goto retry
-	}
-
 	totalLen, err := s.determineTotalPktLen(s.buf)
 	if err != nil {
 		return err
@@ -309,11 +304,6 @@ retry:
 	if err != nil {
 		return -1, fmt.Errorf("error receiving next packet from socket: %w", err)
 	}
-
-	// Apply filter (if any)
-	if filter := s.link.FilterMask(); filter > 0 && filter&pktType != 0 {
-		goto retry
-	}
 	data[0] = pktType
 
 	totalLen, err := s.determineTotalPktLen(data[6:])
@@ -356,11 +346,6 @@ retry:
 	n, pktType, err := s.eventHandler.Recvfrom(data, unix.MSG_DONTWAIT)
 	if err != nil {
 		return -1, capture.PacketUnknown, 0, fmt.Errorf("error receiving next packet from socket: %w", err)
-	}
-
-	// Apply filter (if any)
-	if filter := s.link.FilterMask(); filter > 0 && filter&pktType != 0 {
-		goto retry
 	}
 
 	totalLen, err := s.determineTotalPktLen(data)

--- a/capture/afpacket/afring/afring_zerocopy.go
+++ b/capture/afpacket/afring/afring_zerocopy.go
@@ -13,7 +13,6 @@ import (
 // one (fetching / returning its first packet).
 func (s *Source) NextPayloadZeroCopy() (payload []byte, pktType capture.PacketType, pktLen uint32, err error) {
 
-retry:
 	pktHdr := s.curTPacketHeader
 
 	// If there is an active block, attempt to simply consume a packet from it
@@ -71,11 +70,6 @@ retry:
 	pktHdr.ppos = pktHdr.offsetToFirstPkt()
 
 finalize:
-
-	// Apply filter (if any)
-	if s.filter > 0 && s.filter&pktHdr.data[pktHdr.ppos+58] != 0 {
-		goto retry
-	}
 
 	// Parse the V3 TPacketHeader and the first byte of the payload
 	hdr := pktHdr.parseHeader()
@@ -85,7 +79,6 @@ finalize:
 	return unsafe.Slice(&pktHdr.data[pos], hdr.snaplen),
 		pktHdr.data[pktHdr.ppos+58],
 		hdr.pktLen, nil
-
 }
 
 // NextIPPacketZeroCopy receives the IP layer of the next packet from the source and returns it. The operation is blocking.
@@ -94,7 +87,6 @@ finalize:
 // one (fetching / returning its first packet IP layer).
 func (s *Source) NextIPPacketZeroCopy() (ipLayer capture.IPLayer, pktType capture.PacketType, pktLen uint32, err error) {
 
-retry:
 	pktHdr := s.curTPacketHeader
 
 	// If there is an active block, attempt to simply consume a packet from it
@@ -152,11 +144,6 @@ retry:
 	pktHdr.ppos = pktHdr.offsetToFirstPkt()
 
 finalize:
-
-	// Apply filter (if any)
-	if s.filter > 0 && s.filter&pktHdr.data[pktHdr.ppos+58] != 0 {
-		goto retry
-	}
 
 	// Parse the V3 TPacketHeader and the first byte of the payload
 	hdr := pktHdr.parseHeader()

--- a/link/filter.go
+++ b/link/filter.go
@@ -4,6 +4,24 @@ import "golang.org/x/net/bpf"
 
 const defaultSnapLen = 262144
 
+var bpfInstructionsLinkTypeLoopback = func(snapLen int) []bpf.RawInstruction {
+	if snapLen == 0 {
+		snapLen = defaultSnapLen
+	}
+
+	// LinkTypeLoopback
+	// not outbound && (ether proto 0x0800 || ether proto 0x86DD)
+	return []bpf.RawInstruction{
+		{Op: 0x28, Jt: 0x0, Jf: 0x0, K: 0xfffff004},
+		{Op: 0x15, Jt: 0x4, Jf: 0x0, K: 0x4},
+		{Op: 0x28, Jt: 0x0, Jf: 0x0, K: 0xc},
+		{Op: 0x15, Jt: 0x1, Jf: 0x0, K: 0x800},
+		{Op: 0x15, Jt: 0x0, Jf: 0x1, K: 0x86dd},
+		{Op: 0x6, Jt: 0x0, Jf: 0x0, K: uint32(snapLen)},
+		{Op: 0x6, Jt: 0x0, Jf: 0x0, K: 0x0},
+	}
+}
+
 var bpfInstructionsLinkTypeEther = func(snapLen int) []bpf.RawInstruction {
 	if snapLen == 0 {
 		snapLen = defaultSnapLen

--- a/link/link.go
+++ b/link/link.go
@@ -92,10 +92,10 @@ func (l Type) IPHeaderOffset() byte {
 // BPFFilter returns the link / interface specific raw BPF instructions to filter for valid packets only
 func (l Type) BPFFilter() func(snapLen int) []bpf.RawInstruction {
 	switch l {
-	case TypeLoopback:
-		return bpfInstructionsLinkTypeLoopback
 	case TypeEthernet:
 		return bpfInstructionsLinkTypeEther
+	case TypeLoopback:
+		return bpfInstructionsLinkTypeLoopback
 	case TypePPP,
 		TypeIP6IP6,
 		TypeGRE,

--- a/link/link.go
+++ b/link/link.go
@@ -92,8 +92,9 @@ func (l Type) IPHeaderOffset() byte {
 // BPFFilter returns the link / interface specific raw BPF instructions to filter for valid packets only
 func (l Type) BPFFilter() func(snapLen int) []bpf.RawInstruction {
 	switch l {
-	case TypeEthernet,
-		TypeLoopback:
+	case TypeLoopback:
+		return bpfInstructionsLinkTypeLoopback
+	case TypeEthernet:
 		return bpfInstructionsLinkTypeEther
 	case TypePPP,
 		TypeIP6IP6,
@@ -110,16 +111,6 @@ func (l Type) BPFFilter() func(snapLen int) []bpf.RawInstruction {
 // Link denotes a link, i.e. an interface (wrapped) and its link type
 type Link struct {
 	Interface
-
-	filterMask byte
-}
-
-// WithPacketFilterMask sets / enables a packet type filter (masking) that will be applied
-// during capture
-func WithPacketFilterMask(mask byte) func(l *Link) {
-	return func(l *Link) {
-		l.filterMask |= mask
-	}
 }
 
 // New instantiates a new link / interface
@@ -151,8 +142,7 @@ func New(ifName string, opts ...func(*Link)) (link *Link, err error) {
 	}
 
 	link = &Link{
-		Interface:  iface,
-		filterMask: calculateInitialFilterMask(iface),
+		Interface: iface,
 	}
 
 	// Apply functional options, if any
@@ -166,11 +156,6 @@ func New(ifName string, opts ...func(*Link)) (link *Link, err error) {
 // IsUp returns if a link / interface is up
 func (l *Link) IsUp() (bool, error) {
 	return l.Interface.IsUp()
-}
-
-// FilterMask returns the packet type filter for this link / interface
-func (l *Link) FilterMask() byte {
-	return l.filterMask
 }
 
 // FindAllLinks retrieves all system network interfaces and their link type
@@ -191,16 +176,4 @@ func FindAllLinks() ([]*Link, error) {
 	}
 
 	return links, err
-}
-
-func calculateInitialFilterMask(i Interface) (mask byte) {
-
-	// Loopback devices will show all packets twice (for obvious reasons). In order to avoid
-	// this duplication, a default filter is applied, rejecting all outbound packets (this is
-	// in line with best practices, e.g. handling by libpcap).
-	if i.Type == TypeLoopback {
-		mask |= 4 // capture.PacketOutgoing
-	}
-
-	return
 }

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -149,7 +149,7 @@ func TestLink_BPFFilter(t *testing.T) {
 			name: "Test Loopback link BPF Filter Function",
 			l:    TypeLoopback,
 			wantFunc: func(snapLen int) []bpf.RawInstruction {
-				return bpfInstructionsLinkTypeEther(snapLen)
+				return bpfInstructionsLinkTypeLoopback(snapLen)
 			},
 		},
 		{


### PR DESCRIPTION
@els0r I'm glad this popped up, gave me the chance to rethink the strategy and drop the whole internal filtering complexity in favor of the far more efficient BPF filter logic on kernel level. See Issue comment in #75 for more details:

Benchmarks:
```
                                                 │ nobpf │            bpf            │
                                                 │     sec/op     │    sec/op     vs base               │
CaptureMethods/NextPacket_10485kiBx4-4               78.64n ±  0%   77.22n ±  0%  -1.81% (p=0.000 n=15)
CaptureMethods/NextPacketInPlace_10485kiBx4-4        34.99n ±  1%   34.78n ±  0%  -0.60% (p=0.002 n=15)
CaptureMethods/NextPayload_10485kiBx4-4              69.24n ±  0%   70.26n ±  0%  +1.47% (p=0.000 n=15)
CaptureMethods/NextPayloadInPlace_10485kiBx4-4       29.83n ±  1%   29.66n ±  1%       ~ (p=0.237 n=15)
CaptureMethods/NextPayloadZeroCopy_10485kiBx4-4      17.09n ±  1%   17.05n ±  1%       ~ (p=0.418 n=15)
CaptureMethods/NextIPPacket_10485kiBx4-4             73.32n ±  0%   71.40n ±  0%  -2.62% (p=0.000 n=15)
CaptureMethods/NextIPPacketInPlace_10485kiBx4-4      34.51n ±  1%   32.76n ±  1%  -5.07% (p=0.000 n=15)
CaptureMethods/NextIPPacketZeroCopy_10485kiBx4-4     17.21n ±  1%   17.04n ±  1%  -0.99% (p=0.004 n=15)
CaptureMethods/NextPacketFn_10485kiBx4-4             24.25n ± 11%   23.33n ± 10%       ~ (p=0.267 n=15)
CaptureMethods/NextPacket_10kiBx512-4                205.0n ±  7%   196.5n ±  1%  -4.15% (p=0.000 n=15)
CaptureMethods/NextPacketInPlace_10kiBx512-4         143.4n ±  3%   139.4n ±  1%  -2.79% (p=0.008 n=15)
CaptureMethods/NextPayload_10kiBx512-4               183.4n ±  1%   177.0n ±  2%  -3.49% (p=0.000 n=15)
CaptureMethods/NextPayloadInPlace_10kiBx512-4        144.2n ±  3%   143.3n ±  4%       ~ (p=0.767 n=15)
CaptureMethods/NextPayloadZeroCopy_10kiBx512-4       149.9n ±  2%   143.7n ±  1%  -4.14% (p=0.000 n=15)
CaptureMethods/NextIPPacket_10kiBx512-4              183.9n ±  3%   178.1n ±  2%       ~ (p=0.123 n=15)
CaptureMethods/NextIPPacketInPlace_10kiBx512-4       141.6n ±  2%   139.3n ±  2%  -1.62% (p=0.012 n=15)
CaptureMethods/NextIPPacketZeroCopy_10kiBx512-4      149.6n ±  3%   142.6n ±  2%  -4.68% (p=0.000 n=15)
CaptureMethods/NextPacketFn_10kiBx512-4              145.8n ±  2%   142.2n ±  3%  -2.47% (p=0.012 n=15)
geomean                                              75.78n         74.03n        -2.31%
```

Closes #75 