### PR TITLE
[bugfix] Fix handling of mock snaplen field in pktHdr for packets smaller than snaplen

### DIFF
--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -141,7 +141,7 @@ func (m *MockSource) addPacket(payload []byte, totalLen uint32, pktType, ipLayer
 	block := m.ringBuffer.ring[thisBlock*m.blockSize : thisBlock*m.blockSize+m.blockSize]
 
 	*(*tPacketHeaderV3Mock)(unsafe.Pointer(&block[m.curBlockPos+12])) = tPacketHeaderV3Mock{
-		snaplen: uint32(m.snapLen),
+		snaplen: min(uint32(m.snapLen), totalLen), // The snaplen is set to the totalLen if a packet is shorter
 		pktLen:  totalLen,
 		pktMac:  mac,
 		pktNet:  mac + uint16(m.ipLayerOffset),

--- a/capture/afpacket/afring/afring_zerocopy.go
+++ b/capture/afpacket/afring/afring_zerocopy.go
@@ -76,7 +76,7 @@ finalize:
 	pos := pktHdr.ppos + uint32(hdr.pktMac)
 
 	// Return the payload / IP layer subslice & heeader parameters
-	return unsafe.Slice(&pktHdr.data[pos], hdr.snaplen),
+	return unsafe.Slice(&pktHdr.data[pos], hdr.snaplen), // #nosec: G103
 		pktHdr.data[pktHdr.ppos+58],
 		hdr.pktLen, nil
 }
@@ -150,7 +150,7 @@ finalize:
 	pos := pktHdr.ppos + uint32(hdr.pktNet)
 
 	// Extract the payload (zero-copy) & parameters
-	return unsafe.Slice(&pktHdr.data[pos], hdr.snaplen-s.ipLayerOffsetNum),
+	return unsafe.Slice(&pktHdr.data[pos], hdr.snaplen-s.ipLayerOffsetNum), // #nosec: G103
 		pktHdr.data[pktHdr.ppos+58],
 		hdr.pktLen, nil
 }


### PR DESCRIPTION
Closes #84 