### PR TITLE
[bugfix] Fix handling of mock snaplen field in pktHdr for packets smaller than snaplen

### DIFF
--- a/capture/afpacket/afring/afring.go
+++ b/capture/afpacket/afring/afring.go
@@ -121,7 +121,7 @@ func NewSourceFromLink(link *link.Link, options ...Option) (*Source, error) {
 // NextIPPacket() methods (the latter two by calling .Payload() / .IPLayer() on the created buffer). It ensures
 // that a valid packet of appropriate structure / length is created
 func (s *Source) NewPacket() capture.Packet {
-	p := make(capture.Packet, 6+s.snapLen)
+	p := make(capture.Packet, capture.PacketHdrOffset+s.snapLen)
 	return p
 }
 

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -141,7 +141,7 @@ func (m *MockSource) addPacket(payload []byte, totalLen uint32, pktType, ipLayer
 	block := m.ringBuffer.ring[thisBlock*m.blockSize : thisBlock*m.blockSize+m.blockSize]
 
 	*(*tPacketHeaderV3Mock)(unsafe.Pointer(&block[m.curBlockPos+12])) = tPacketHeaderV3Mock{
-		snaplen: min(uint32(m.snapLen), uint32(len(payload))), // The snaplen is set to the totalLen if a packet is shorter
+		snaplen: min(uint32(m.snapLen), uint32(len(payload))), // The snaplen is set to the actual payload length if a packet is shorter
 		pktLen:  totalLen,
 		pktMac:  mac,
 		pktNet:  mac + uint16(m.ipLayerOffset),

--- a/capture/afpacket/afring/afring_mock.go
+++ b/capture/afpacket/afring/afring_mock.go
@@ -141,7 +141,7 @@ func (m *MockSource) addPacket(payload []byte, totalLen uint32, pktType, ipLayer
 	block := m.ringBuffer.ring[thisBlock*m.blockSize : thisBlock*m.blockSize+m.blockSize]
 
 	*(*tPacketHeaderV3Mock)(unsafe.Pointer(&block[m.curBlockPos+12])) = tPacketHeaderV3Mock{
-		snaplen: min(uint32(m.snapLen), totalLen), // The snaplen is set to the totalLen if a packet is shorter
+		snaplen: min(uint32(m.snapLen), uint32(len(payload))), // The snaplen is set to the totalLen if a packet is shorter
 		pktLen:  totalLen,
 		pktMac:  mac,
 		pktNet:  mac + uint16(m.ipLayerOffset),


### PR DESCRIPTION
Second attempt - took the wrong default value and found a few other unwanted side-effect / inconsistencies that only occur for the edge case of payloads smaller than the snaplen _and_ situations where it's important that the data length isn't spare.

Closes #84 